### PR TITLE
Add @babel/plugin-transform-runtime

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@spark-web/docs"]
 }

--- a/.changeset/plenty-apricots-give.md
+++ b/.changeset/plenty-apricots-give.md
@@ -1,0 +1,39 @@
+---
+'@spark-web/a11y': patch
+'@spark-web/accordion': patch
+'@spark-web/alert': patch
+'@spark-web/analytics': patch
+'@spark-web/box': patch
+'@spark-web/button': patch
+'@spark-web/checkbox': patch
+'@spark-web/columns': patch
+'@spark-web/container': patch
+'@spark-web/control-label': patch
+'@spark-web/core': patch
+'@spark-web/divider': patch
+'@spark-web/dropzone': patch
+'@spark-web/field': patch
+'@spark-web/fieldset': patch
+'@spark-web/heading': patch
+'@spark-web/hidden': patch
+'@spark-web/icon': patch
+'@spark-web/inline': patch
+'@spark-web/link': patch
+'@spark-web/modal-dialog': patch
+'@spark-web/nav-link': patch
+'@spark-web/next-utils': patch
+'@spark-web/radio': patch
+'@spark-web/row': patch
+'@spark-web/select': patch
+'@spark-web/ssr': patch
+'@spark-web/stack': patch
+'@spark-web/text': patch
+'@spark-web/text-area': patch
+'@spark-web/text-input': patch
+'@spark-web/text-link': patch
+'@spark-web/text-list': patch
+'@spark-web/theme': patch
+'@spark-web/utils': patch
+---
+
+Add @babel/transform-runtime

--- a/babel.config.json
+++ b/babel.config.json
@@ -8,5 +8,6 @@
         "runtime": "automatic"
       }
     ]
-  ]
+  ],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.16.5",
-    "@babel/plugin-transform-runtime": "^7.14.5",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,7 +948,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-runtime@^7.14.5":
+"@babel/plugin-transform-runtime@^7.17.0":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz#0a2e08b5e2b2d95c4b1d3b3371a2180617455b70"
   integrity sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==


### PR DESCRIPTION
The SSR package was trying to use a global (`regeneratorRuntime`) which wasn't being defined:

![next-error](https://user-images.githubusercontent.com/3422401/164953832-ef0de59b-6233-4b15-b1d7-8db3c345931b.png)

[@babel/plugin-transform-runtime](https://babel.dev/docs/en/babel-plugin-transform-runtime#regenerator) adds this for us automatically (and it also claims to help reduce bundle size).

I've tested this locally and it seems to be working as expected.

I've also bumped the versions of our packages since Babel (which Preconstruct runs on all of our packages to create the builds) will output slightly different code now that we're using the transform runtime plugin.
