### PR TITLE
Fix multiple versions of React

### DIFF
--- a/.changeset/spicy-bees-reply.md
+++ b/.changeset/spicy-bees-reply.md
@@ -1,0 +1,38 @@
+---
+'@spark-web/a11y': patch
+'@spark-web/accordion': patch
+'@spark-web/alert': patch
+'@spark-web/analytics': patch
+'@spark-web/box': patch
+'@spark-web/button': patch
+'@spark-web/checkbox': patch
+'@spark-web/columns': patch
+'@spark-web/container': patch
+'@spark-web/control-label': patch
+'@spark-web/core': patch
+'@spark-web/divider': patch
+'@spark-web/dropzone': patch
+'@spark-web/field': patch
+'@spark-web/fieldset': patch
+'@spark-web/heading': patch
+'@spark-web/hidden': patch
+'@spark-web/icon': patch
+'@spark-web/inline': patch
+'@spark-web/link': patch
+'@spark-web/modal-dialog': patch
+'@spark-web/nav-link': patch
+'@spark-web/next-utils': patch
+'@spark-web/radio': patch
+'@spark-web/row': patch
+'@spark-web/select': patch
+'@spark-web/stack': patch
+'@spark-web/text': patch
+'@spark-web/text-area': patch
+'@spark-web/text-input': patch
+'@spark-web/text-link': patch
+'@spark-web/text-list': patch
+'@spark-web/theme': patch
+'@spark-web/utils': patch
+---
+
+Prevent multiple versions of React

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/theme": "^2.0.1",
     "@spark-web/utils": "^1.0.2",
-    "polished": "^4.1.3",
-    "react": "^17.0.2"
+    "polished": "^4.1.3"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -13,11 +13,14 @@
     "@spark-web/icon": "^1.0.2",
     "@spark-web/stack": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -12,11 +12,14 @@
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/text-list": "^1.0.2",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,11 +5,14 @@
   "main": "dist/spark-web-analytics.cjs.js",
   "module": "dist/spark-web-analytics.esm.js",
   "dependencies": {
-    "@babel/runtime": "^7.14.6",
-    "react": "^17.0.2"
+    "@babel/runtime": "^7.14.6"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -8,11 +8,14 @@
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -13,11 +13,14 @@
     "@spark-web/link": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -14,8 +14,14 @@
     "@spark-web/icon": "^1.0.2",
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
-    "@spark-web/theme": "^2.0.1",
+    "@spark-web/theme": "^2.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.12",
     "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/columns/package.json
+++ b/packages/columns/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/control-label/package.json
+++ b/packages/control-label/package.json
@@ -8,8 +8,14 @@
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
-    "@spark-web/text": "^1.0.2",
+    "@spark-web/text": "^1.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.12",
     "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,12 +12,15 @@
     "@spark-web/link": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
     "@spark-web/utils": "^1.0.2",
-    "assert": "1.5.0",
-    "react": "^17.0.2"
+    "assert": "1.5.0"
   },
   "devDependencies": {
     "@types/assert": "^1.5.6",
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -7,11 +7,14 @@
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",
-    "@spark-web/theme": "^2.0.1",
-    "react": "^17.0.2"
+    "@spark-web/theme": "^2.0.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -18,8 +18,14 @@
     "@spark-web/text-list": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
     "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2",
     "react-dropzone": "^12.0.4"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -13,11 +13,14 @@
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
     "@spark-web/text": "^1.0.2",
-    "@spark-web/theme": "^2.0.1",
-    "react": "^17.0.2"
+    "@spark-web/theme": "^2.0.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -10,11 +10,14 @@
     "@spark-web/box": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/hidden/package.json
+++ b/packages/hidden/package.json
@@ -11,11 +11,14 @@
     "@spark-web/heading": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -9,8 +9,7 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.1.0",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.12",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -13,7 +13,11 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -8,11 +8,14 @@
     "@babel/runtime": "^7.14.6",
     "@spark-web/box": "^1.0.2",
     "@spark-web/utils": "^1.0.2",
-    "dedent": "^0.7.0",
-    "react": "^17.0.2"
+    "dedent": "^0.7.0"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/modal-dialog/package.json
+++ b/packages/modal-dialog/package.json
@@ -16,11 +16,14 @@
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/nav-link/package.json
+++ b/packages/nav-link/package.json
@@ -11,11 +11,14 @@
     "@spark-web/box": "^1.0.2",
     "@spark-web/link": "^1.0.2",
     "@spark-web/text": "^1.0.2",
-    "@spark-web/theme": "^2.0.1",
-    "react": "^17.0.2"
+    "@spark-web/theme": "^2.0.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/next-utils/package.json
+++ b/packages/next-utils/package.json
@@ -8,11 +8,14 @@
     "@babel/runtime": "^7.14.6",
     "@spark-web/link": "^1.0.2",
     "@spark-web/ssr": "1.0.2",
-    "next": "^12.0.7",
-    "react": "^17.0.2"
+    "next": "^12.0.7"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -14,8 +14,14 @@
     "@spark-web/icon": "^1.0.2",
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
-    "@spark-web/theme": "^2.0.1",
+    "@spark-web/theme": "^2.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.12",
     "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -10,11 +10,14 @@
     "@spark-web/box": "^1.0.2",
     "@spark-web/divider": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -14,11 +14,14 @@
     "@spark-web/text": "^1.0.2",
     "@spark-web/text-input": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -10,11 +10,14 @@
     "@spark-web/box": "^1.0.2",
     "@spark-web/divider": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -12,11 +12,14 @@
     "@spark-web/text": "^1.0.2",
     "@spark-web/text-input": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -12,11 +12,14 @@
     "@spark-web/field": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -12,11 +12,14 @@
     "@spark-web/link": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/text-list/package.json
+++ b/packages/text-list/package.json
@@ -12,11 +12,14 @@
     "@spark-web/stack": "^1.0.2",
     "@spark-web/text": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -9,11 +9,14 @@
     "@emotion/css": "^11.7.1",
     "@spark-web/box": "^1.0.2",
     "@spark-web/theme": "^2.0.1",
-    "@spark-web/utils": "^1.0.2",
-    "react": "^17.0.2"
+    "@spark-web/utils": "^1.0.2"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -12,12 +12,15 @@
     "@spark-web/utils": "^1.0.2",
     "facepaint": "^1.2.1",
     "lodash": "^4.17.21",
-    "polished": "^4.1.3",
-    "react": "^17.0.2"
+    "polished": "^4.1.3"
   },
   "devDependencies": {
     "@types/facepaint": "^1.2.2",
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,11 +5,14 @@
   "main": "dist/spark-web-utils.cjs.js",
   "module": "dist/spark-web-utils.esm.js",
   "dependencies": {
-    "@babel/runtime": "^7.14.6",
-    "react": "^17.0.2"
+    "@babel/runtime": "^7.14.6"
   },
   "devDependencies": {
-    "@types/react": "^17.0.12"
+    "@types/react": "^17.0.12",
+    "react": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.2"
   },
   "engines": {
     "node": ">= 14.13"


### PR DESCRIPTION
When using Spark Web with a fresh install of Next.js (which uses React 18 by default) I get the following error:

![PixelSnap 2022-04-26 at 16 03 50@2x](https://user-images.githubusercontent.com/3422401/165232630-b630dc09-11ea-4064-9d85-965246d8f53c.png)

Looks like this is because we're shipping React 17.0.2 with the design system.

To address this by moving React _out_ of our `dependencies`, _into_ our `devDependencies` and adding `"react": ">=17.0.2"` to our `peerDependencies`.

I've also sorted the `package.json` files using [this npx script](https://www.npmjs.com/package/sort-package-json) to  make the find-and-replace a little easier.