### PR TITLE
Add clean scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   ],
   "scripts": {
     "build": "preconstruct build",
+    "clean:check": "git clean -nXd",
+    "clean:docs": "yarn --cwd=docs git clean -fXd",
+    "clean:packages": "yarn --cwd=packages git clean -fXd",
+    "clean:write": "git clean -fXd",
     "docs:build": "yarn --cwd=docs build",
     "docs:start": "yarn --cwd=docs start",
     "format": "prettier --check . --ignore-path \"./.gitignore\"",


### PR DESCRIPTION
If you have a folder in the `packages` directory without a `package.json` or `README.md` the docs will fail to build. This happens to me all the time when switching between feature branches.
Running `yarn clean:packages` will delete all the temporary files in that directory. You can then run `yarn && yarn start` to start the docs.
We also generate a lot of assets inside the `docs` directory (`.next` folder as well as Storybook and Playroom).
Running `yarn clean:docs` will delete all the temporary files in the docs directory.
Sometimes you just want to delete _all_ the temporary files. In that case you can run `yarn clean:write`.