### PR TITLE
Add files array to package.json

### DIFF
--- a/.changeset/quick-stingrays-worry.md
+++ b/.changeset/quick-stingrays-worry.md
@@ -1,0 +1,41 @@
+---
+'@spark-web/a11y': patch
+'@spark-web/accordion': patch
+'@spark-web/alert': patch
+'@spark-web/analytics': patch
+'@spark-web/box': patch
+'@spark-web/button': patch
+'@spark-web/checkbox': patch
+'@spark-web/columns': patch
+'@spark-web/container': patch
+'@spark-web/control-label': patch
+'@spark-web/core': patch
+'@spark-web/divider': patch
+'@spark-web/dropzone': patch
+'@spark-web/field': patch
+'@spark-web/fieldset': patch
+'@spark-web/float-input': patch
+'@spark-web/heading': patch
+'@spark-web/hidden': patch
+'@spark-web/icon': patch
+'@spark-web/inline': patch
+'@spark-web/link': patch
+'@spark-web/modal-dialog': patch
+'@spark-web/nav-link': patch
+'@spark-web/next-utils': patch
+'@spark-web/radio': patch
+'@spark-web/row': patch
+'@spark-web/select': patch
+'@spark-web/spinner': patch
+'@spark-web/ssr': patch
+'@spark-web/stack': patch
+'@spark-web/text': patch
+'@spark-web/text-area': patch
+'@spark-web/text-input': patch
+'@spark-web/text-link': patch
+'@spark-web/text-list': patch
+'@spark-web/theme': patch
+'@spark-web/utils': patch
+---
+
+Add files array to package.json files

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-a11y.cjs.js",
   "module": "dist/spark-web-a11y.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-accordion.cjs.js",
   "module": "dist/spark-web-accordion.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-alert.cjs.js",
   "module": "dist/spark-web-alert.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-analytics.cjs.js",
   "module": "dist/spark-web-analytics.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6"
   },

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-box.cjs.js",
   "module": "dist/spark-web-box.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-button.cjs.js",
   "module": "dist/spark-web-button.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-checkbox.cjs.js",
   "module": "dist/spark-web-checkbox.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/columns/package.json
+++ b/packages/columns/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-columns.cjs.js",
   "module": "dist/spark-web-columns.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-container.cjs.js",
   "module": "dist/spark-web-container.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/control-label/package.json
+++ b/packages/control-label/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-control-label.cjs.js",
   "module": "dist/spark-web-control-label.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-core.cjs.js",
   "module": "dist/spark-web-core.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-divider.cjs.js",
   "module": "dist/spark-web-divider.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-dropzone.cjs.js",
   "module": "dist/spark-web-dropzone.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-field.cjs.js",
   "module": "dist/spark-web-field.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-fieldset.cjs.js",
   "module": "dist/spark-web-fieldset.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/float-input/package.json
+++ b/packages/float-input/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-float-input.cjs.js",
   "module": "dist/spark-web-float-input.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-heading.cjs.js",
   "module": "dist/spark-web-heading.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/hidden/package.json
+++ b/packages/hidden/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-hidden.cjs.js",
   "module": "dist/spark-web-hidden.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-icon.cjs.js",
   "module": "dist/spark-web-icon.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-inline.cjs.js",
   "module": "dist/spark-web-inline.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-link.cjs.js",
   "module": "dist/spark-web-link.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@spark-web/box": "^1.0.3",

--- a/packages/modal-dialog/package.json
+++ b/packages/modal-dialog/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-modal-dialog.cjs.js",
   "module": "dist/spark-web-modal-dialog.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/nav-link/package.json
+++ b/packages/nav-link/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-nav-link.cjs.js",
   "module": "dist/spark-web-nav-link.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/next-utils/package.json
+++ b/packages/next-utils/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-next-utils.cjs.js",
   "module": "dist/spark-web-next-utils.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@spark-web/link": "^1.0.3",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-radio.cjs.js",
   "module": "dist/spark-web-radio.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-row.cjs.js",
   "module": "dist/spark-web-row.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-select.cjs.js",
   "module": "dist/spark-web-select.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-spinner.cjs.js",
   "module": "dist/spark-web-spinner.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-ssr.cjs.js",
   "module": "dist/spark-web-ssr.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-stack.cjs.js",
   "module": "dist/spark-web-stack.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-text-area.cjs.js",
   "module": "dist/spark-web-text-area.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-text-input.cjs.js",
   "module": "dist/spark-web-text-input.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/text-link/package.json
+++ b/packages/text-link/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-text-link.cjs.js",
   "module": "dist/spark-web-text-link.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/text-list/package.json
+++ b/packages/text-list/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-text-list.cjs.js",
   "module": "dist/spark-web-text-list.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-text.cjs.js",
   "module": "dist/spark-web-text.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@emotion/css": "^11.7.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "main": "dist/spark-web-theme.cjs.js",
   "module": "dist/spark-web-theme.esm.js",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@capsizecss/core": "^3.0.0",

--- a/packages/utils/internal/package.json
+++ b/packages/utils/internal/package.json
@@ -1,4 +1,7 @@
 {
   "main": "dist/spark-web-utils-internal.cjs.js",
-  "module": "dist/spark-web-utils-internal.esm.js"
+  "module": "dist/spark-web-utils-internal.esm.js",
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,11 @@
   "license": "MIT",
   "main": "dist/spark-web-utils.cjs.js",
   "module": "dist/spark-web-utils.esm.js",
+  "files": [
+    "dist",
+    "internal",
+    "ts"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.14.6"
   },

--- a/packages/utils/ts/package.json
+++ b/packages/utils/ts/package.json
@@ -1,4 +1,7 @@
 {
   "main": "dist/spark-web-utils-ts.cjs.js",
-  "module": "dist/spark-web-utils-ts.esm.js"
+  "module": "dist/spark-web-utils-ts.esm.js",
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
Currently we're shipping the entire content of the package directory with all of our packages:
<https://unpkg.com/browse/@spark-web/button@1.0.3/>
We only need to package the contents of the `dist` directory, so adding it to every `package.json` file in the `packages` directory should dramatically reduce the library size.

See: <https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files>