### PR TITLE
Add VSCode workspace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# VSCode plugin: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+# More info: https://editorconfig.org/
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*.{ts,tsx,js,jsx,json}]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode",
+    "naumovs.color-highlight"
+  ]
+}

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,0 +1,19 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "eslint.packageManager": "yarn",
+  "eslint.validate": [
+    "javascript"
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": false
+  },
+  "[javascriptreact]": {
+    "editor.formatOnSave": false
+  }
+}


### PR DESCRIPTION
Add VSCode workspace extensions and recommended settings.
Mostly the same as what we had in the energy monorepo, lightly edited with some settings that I've found to be more reliable ([borrowed from here](https://github.com/wesbos/eslint-config-wesbos#with-vs-code)).