### PR TITLE
Patch for loader animation

### DIFF
--- a/.changeset/seven-suns-explode.md
+++ b/.changeset/seven-suns-explode.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/spinner': patch
+---
+
+Patched loader animation so that it doesn't disappear on last keyframe.

--- a/packages/spinner/src/Spinner.tsx
+++ b/packages/spinner/src/Spinner.tsx
@@ -41,15 +41,14 @@ const spinAnimation = keyframes({
 
 const strokeDashAnimation = keyframes({
   '0%': { strokeDasharray: '1px, 200px', strokeDashoffset: 0 },
-  '50%': { strokeDasharray: '100px, 200px', strokeDashoffset: '-15px' },
-  '100%': { strokeDasharray: '100px, 200px', strokeDashoffset: '-125px' },
+  '100%': { strokeDasharray: '200px, 200px', strokeDashoffset: '-55px' },
 });
 
 function useSpinnerStyles() {
   return {
     animation: `${spinAnimation} 1.4s linear infinite`,
     '& circle': {
-      animation: `${strokeDashAnimation} 1.4s ease-in-out infinite`,
+      animation: `${strokeDashAnimation} 1.6s cubic-bezier(0.47, 0, 0.75, 0.72) infinite`,
     },
   } as const;
 }


### PR DESCRIPTION
At the moment, the spinner disappears on the 100% keyframe. I’d like to retain a piece of the circle so that the spinner never completely disappears as it loops.