### PR TITLE
Fix/sprk 58 fix math error in dropzone component

### DIFF
--- a/.changeset/wild-snails-judge.md
+++ b/.changeset/wild-snails-judge.md
@@ -2,6 +2,6 @@
 '@spark-web/dropzone': major
 ---
 
-WHAT dropzone component updated to receive min/max filesize in kb
-WHY currently component is doing incorrect calculation to convert kilobytes to bytes
-HOW all max and min file size values should be added in kilobytes
+WHAT dropzone component updated to receive min/max filesize in kb WHY currently
+component is doing incorrect calculation to convert kilobytes to bytes HOW all
+max and min file size values should be added in kilobytes

--- a/.changeset/wild-snails-judge.md
+++ b/.changeset/wild-snails-judge.md
@@ -1,0 +1,7 @@
+---
+'@spark-web/dropzone': major
+---
+
+WHAT dropzone component updated to receive min/max filesize in kb
+WHY currently component is doing incorrect calculation to convert kilobytes to bytes
+HOW all max and min file size values should be added in kilobytes

--- a/.changeset/wild-snails-judge.md
+++ b/.changeset/wild-snails-judge.md
@@ -2,6 +2,9 @@
 '@spark-web/dropzone': major
 ---
 
-WHAT dropzone component updated to receive min/max filesize in kb WHY currently
-component is doing incorrect calculation to convert kilobytes to bytes HOW all
-max and min file size values should be added in kilobytes
+WHAT dropzone component updated to receive min/max filesize in kb
+
+WHY currently component is doing incorrect calculation to convert kilobytes to
+bytes
+
+HOW all max and min file size values should be added in kilobytes

--- a/packages/dropzone/src/dropzone.tsx
+++ b/packages/dropzone/src/dropzone.tsx
@@ -372,7 +372,7 @@ function useDropzoneStyles({
 
 function formatFileSize(numKb: number): string {
   if (numKb < 1000) {
-    return `${Math.round(numKb).toFixed(1)}kB`;
+    return `${Math.round(numKb).toFixed()}kB`;
   }
-  return `${Math.round(numKb / 1000).toFixed(1)}MB`;
+  return `${Math.round(numKb / 1000).toFixed()}MB`;
 }

--- a/packages/dropzone/src/dropzone.tsx
+++ b/packages/dropzone/src/dropzone.tsx
@@ -40,9 +40,9 @@ export type DropzoneProps = InputProps & {
   accept?: AcceptedType | AcceptedType[];
   /** Maximum number of files that the Dropzone should be allowed to accept. */
   maxFiles?: number;
-  /** Maximum file size that the Dropzone should be allowed to accept. */
+  /** Maximum file size that the Dropzone should be allowed to accept. Value should be provided in kB */
   maxFileSizeKb?: number;
-  /** Minimum file size that the Dropzone should be allowed to accept. */
+  /** Minimum file size that the Dropzone should be allowed to accept. Value should be provided in kB */
   minFileSizeKb?: number;
   /** When true, renders an image preview next to file previews. */
   showImageThumbnails?: boolean;
@@ -96,8 +96,8 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
     } = useDropzone({
       accept,
       maxFiles,
-      maxSize: maxFileSizeKb && maxFileSizeKb / 1000,
-      minSize: minFileSizeKb && minFileSizeKb / 1000,
+      maxSize: maxFileSizeKb && maxFileSizeKb * 1000,
+      minSize: minFileSizeKb && minFileSizeKb * 1000,
       multiple: maxFiles > 1,
       onDropAccepted: handleDropAccepted,
       disabled,

--- a/packages/dropzone/src/dropzone.tsx
+++ b/packages/dropzone/src/dropzone.tsx
@@ -96,8 +96,8 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
     } = useDropzone({
       accept,
       maxFiles,
-      maxSize: maxFileSizeKb && maxFileSizeKb / 1024,
-      minSize: minFileSizeKb && minFileSizeKb / 1024,
+      maxSize: maxFileSizeKb && maxFileSizeKb / 1000,
+      minSize: minFileSizeKb && minFileSizeKb / 1000,
       multiple: maxFiles > 1,
       onDropAccepted: handleDropAccepted,
       disabled,
@@ -371,8 +371,8 @@ function useDropzoneStyles({
 }
 
 function formatFileSize(numKb: number): string {
-  if (numKb < 1024) {
+  if (numKb < 1000) {
     return `${Math.round(numKb).toFixed(1)}kB`;
   }
-  return `${Math.round(numKb / 1024).toFixed(1)}MB`;
+  return `${Math.round(numKb / 1000).toFixed(1)}MB`;
 }


### PR DESCRIPTION
This PR consists of two changes. 

The first change updates the number of bytes in a kB from 1024 to 1000. 
The second change updates the calculation to provide the max and min file size to the Dropzone component in Bytes (https://react-dropzone.js.org/). 

A subsequent ticket will be raised to cover the testing of this component as agreed with Luke. 