### PR TITLE
Update React imports

### DIFF
--- a/docs/components/example-helpers.tsx
+++ b/docs/components/example-helpers.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { Box } from '@spark-web/box';
 import { Text, useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 // Code
 // ------------------------------
@@ -11,7 +11,7 @@ const CodeElement = ({
   inline,
   ...props
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   inline?: boolean;
 }) => {
   const textStyles = useText({
@@ -69,7 +69,7 @@ export const InlineCode = ({ children }: { children: string }) => {
 type PlaceholderProps = {
   height?: string | number;
   width?: string | number;
-  label?: React.ReactNode;
+  label?: ReactNode;
   shape?: 'rectangle' | 'round';
 };
 

--- a/docs/components/layout.tsx
+++ b/docs/components/layout.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { Box } from '@spark-web/box';
 import { useTheme } from '@spark-web/theme';
+import type { ReactNode } from 'react';
 
 import { Header } from './header';
 import type { SidebarNavItemType } from './sidebar';
@@ -11,7 +12,7 @@ export function Layout({
   children,
 }: {
   navigation: SidebarNavItemType[];
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   const theme = useTheme();
   return (

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -5,6 +5,7 @@ import { Strong, Text } from '@spark-web/text';
 import { TextLink } from '@spark-web/text-link';
 import type { TextListProps } from '@spark-web/text-list';
 import { TextList } from '@spark-web/text-list';
+import type { ReactNode } from 'react';
 import { Children, Fragment } from 'react';
 
 import * as sparkComponents from '../../cache/spark-components';
@@ -51,7 +52,7 @@ const TextListMdx = (props: TextListProps) => (
   </TextList>
 );
 
-export const mdxComponents: Record<string, React.ReactNode> = {
+export const mdxComponents: Record<string, ReactNode> = {
   // Native HTML elements
   a: TextLink,
   p: (props: TextProps) => {

--- a/docs/components/mdx-components/mdx-table.tsx
+++ b/docs/components/mdx-components/mdx-table.tsx
@@ -3,13 +3,13 @@ import { Box } from '@spark-web/box';
 import { useHeading } from '@spark-web/heading';
 import { Text } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 export function MdxTable({
   children,
   ...rest
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   const theme = useTheme();
   return (
@@ -46,7 +46,7 @@ export function MdxThead({
   children,
   ...rest
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   return (
     <Box as="thead" background="surface" {...rest}>
@@ -59,7 +59,7 @@ export function MdxTr({
   children,
   ...rest
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   const theme = useTheme();
   return (
@@ -85,7 +85,7 @@ export function MdxTh({
   children,
   ...rest
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   const { border, spacing } = useTheme();
   const textStyles = useHeading({ align: 'left', level: '4' });
@@ -109,7 +109,7 @@ export function MdxTd({
   children,
   ...rest
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   const theme = useTheme();
   return (

--- a/docs/components/mdx-components/react-live.tsx
+++ b/docs/components/mdx-components/react-live.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '@spark-web/theme';
 import { useLiveCode } from '@untitled-docs/live-code';
 import copy from 'clipboard-copy';
 import { createUrl } from 'playroom/utils';
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import Editor from 'react-simple-code-editor';
 
@@ -88,7 +89,7 @@ function RenderedCodeExample({
   children,
   styles,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   styles?: CSSObject;
 }) {
   const { color, border } = useTheme();
@@ -111,7 +112,7 @@ function ErrorMessage({
   children,
   styles,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   styles?: CSSObject;
 }) {
   const { color, border } = useTheme();

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { NavLink } from '@spark-web/nav-link';
 import { Stack } from '@spark-web/stack';
 import { useTheme } from '@spark-web/theme';
 import { useRouter } from 'next/router';
+import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
 import { HEADER_HEIGHT, SIDEBAR_WIDTH } from './constants';
@@ -82,7 +83,7 @@ export const SidebarContext = createContext<SidebarContextType | null>(null);
 export const SidebarContextProvider = ({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) => {
   const [sidebarIsOpen, setOpen] = useState(false);
 

--- a/docs/playroom/frame.tsx
+++ b/docs/playroom/frame.tsx
@@ -1,10 +1,10 @@
 import { SparkProvider } from '@spark-web/core';
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 export default function FrameComponent({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }): JSX.Element {
   return <SparkProvider>{children}</SparkProvider>;
 }

--- a/packages/a11y/src/idContext.tsx
+++ b/packages/a11y/src/idContext.tsx
@@ -4,7 +4,8 @@
 // Replace with React core `useId` when appropriate:
 // See: https://github.com/reactwg/react-18/discussions/111
 
-import * as React from 'react';
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 type IdContextValue = {
   prefix: number;
@@ -16,13 +17,13 @@ const defaultIdContext: IdContextValue = {
   current: 0,
 };
 
-const IdContext = React.createContext<IdContextValue>(defaultIdContext);
+const IdContext = createContext<IdContextValue>(defaultIdContext);
 
 /** Provide stable IDs in server rendered environments. */
-export function IdProvider({ children }: { children: React.ReactNode }) {
-  const currentContext = React.useContext(IdContext);
+export function IdProvider({ children }: { children: ReactNode }) {
+  const currentContext = useContext(IdContext);
   const isRootIdProvider = currentContext === defaultIdContext;
-  const context: IdContextValue = React.useMemo(
+  const context: IdContextValue = useMemo(
     () => ({
       prefix: isRootIdProvider ? 0 : ++currentContext.prefix,
       current: 0,
@@ -38,7 +39,7 @@ export function IdProvider({ children }: { children: React.ReactNode }) {
 
 /** Generate a unique ID. */
 export function useId(deterministicId?: string): string {
-  const context = React.useContext(IdContext);
+  const context = useContext(IdContext);
   const isBrowser = Boolean(globalThis?.document);
 
   if (!isBrowser && context === defaultIdContext) {
@@ -48,7 +49,7 @@ export function useId(deterministicId?: string): string {
     );
   }
 
-  return React.useMemo(
+  return useMemo(
     () =>
       deterministicId || `brighte-id-${context.prefix}-${++context.current}`,
     [context, deterministicId]

--- a/packages/accordion/src/Accordion.tsx
+++ b/packages/accordion/src/Accordion.tsx
@@ -10,7 +10,7 @@ import { Heading } from '@spark-web/heading';
 import { ChevronDownIcon } from '@spark-web/icon';
 import { Stack } from '@spark-web/stack';
 import { useTheme } from '@spark-web/theme';
-import * as React from 'react';
+import type { RefAttributes } from 'react';
 
 const openAnimation = keyframes({
   from: {
@@ -93,10 +93,8 @@ export function AccordionItem({
 }
 
 export type AccordionProps =
-  | (Omit<AccordionSingleProps, 'asChild'> &
-      React.RefAttributes<HTMLDivElement>)
-  | (Omit<AccordionMultipleProps, 'asChild'> &
-      React.RefAttributes<HTMLDivElement>);
+  | (Omit<AccordionSingleProps, 'asChild'> & RefAttributes<HTMLDivElement>)
+  | (Omit<AccordionMultipleProps, 'asChild'> & RefAttributes<HTMLDivElement>);
 
 export function Accordion({ children, ...rest }: AccordionProps): JSX.Element {
   return (

--- a/packages/alert/src/Alert.tsx
+++ b/packages/alert/src/Alert.tsx
@@ -10,12 +10,13 @@ import { Stack } from '@spark-web/stack';
 import { Text } from '@spark-web/text';
 import { IndicatorContainer } from '@spark-web/text-list';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import * as React from 'react';
+import type { ReactNode } from 'react';
+import { Fragment } from 'react';
 
 type AlertTones = 'caution' | 'critical' | 'info' | 'positive';
 
 export type AlertProps = {
-  children: string | React.ReactNode;
+  children: string | ReactNode;
   closeLabel?: string;
   data?: DataAttributeMap;
   heading?: string;
@@ -96,10 +97,10 @@ const toneToIcon = {
   positive: CheckCircleIcon,
 };
 
-const Content = ({ children }: { children: React.ReactNode }) => {
+const Content = ({ children }: { children: ReactNode }) => {
   if (typeof children === 'string' || typeof children === 'number') {
     return <Text>{children}</Text>;
   }
 
-  return <React.Fragment>{children}</React.Fragment>;
+  return <Fragment>{children}</Fragment>;
 };

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@spark-web/box';
 import { buildDataAttributes } from '@spark-web/utils/internal';
-import * as React from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { forwardRef } from 'react';
 
 import { resolveButtonChildren } from './resolveButtonChildren';
 import type { CommonButtonProps, NativeButtonProps } from './types';
@@ -28,7 +29,7 @@ export type ButtonProps = CommonButtonProps & {
  * Buttons are used to initialize an action, their label should express what
  * action will occur when the user interacts with it.
  */
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       'aria-controls': ariaControls,
@@ -99,7 +100,7 @@ export function getPreventableClickHandler(
   disabled: boolean
 ) {
   return function handleClick(
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: ReactMouseEvent<HTMLButtonElement, MouseEvent>
   ) {
     if (disabled) {
       event.preventDefault();

--- a/packages/control-label/src/control-label.tsx
+++ b/packages/control-label/src/control-label.tsx
@@ -1,10 +1,11 @@
 import { Box } from '@spark-web/box';
 import { DefaultTextPropsProvider, Text } from '@spark-web/text';
-import * as React from 'react';
+import type { ReactNode } from 'react';
+import { Fragment } from 'react';
 
 export type ControlLabelProps = {
-  children: React.ReactNode;
-  control: React.ReactNode;
+  children: ReactNode;
+  control: ReactNode;
   disabled?: boolean;
   htmlFor?: string;
   size: 'small' | 'medium';
@@ -34,10 +35,10 @@ export function ControlLabel({
   );
 }
 
-function Content({ children }: { children: React.ReactNode }) {
+function Content({ children }: { children: ReactNode }) {
   if (typeof children === 'string' || typeof children === 'number') {
     return <Text>{children}</Text>;
   }
 
-  return <React.Fragment>{children}</React.Fragment>;
+  return <Fragment>{children}</Fragment>;
 }

--- a/packages/dropzone/src/dropzone.tsx
+++ b/packages/dropzone/src/dropzone.tsx
@@ -9,7 +9,8 @@ import { Text } from '@spark-web/text';
 import { TextList } from '@spark-web/text-list';
 import { useTheme } from '@spark-web/theme';
 import { mergeRefs } from '@spark-web/utils';
-import * as React from 'react';
+import type { InputHTMLAttributes } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import type {
   ErrorCode as DropzoneErrorCode,
   FileWithPath,
@@ -32,7 +33,7 @@ type FileWithPreview = FileWithPath & {
 };
 
 type InputProps = Pick<
-  React.InputHTMLAttributes<HTMLInputElement>,
+  InputHTMLAttributes<HTMLInputElement>,
   'name' | 'onChange' | 'onBlur'
 >;
 export type DropzoneProps = InputProps & {
@@ -48,7 +49,7 @@ export type DropzoneProps = InputProps & {
   showImageThumbnails?: boolean;
 };
 
-export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
+export const Dropzone = forwardRef<HTMLInputElement, DropzoneProps>(
   (
     {
       accept,
@@ -62,8 +63,8 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
     },
     forwardedRef
   ) => {
-    const [files, setFiles] = React.useState<FileWithPreview[]>([]);
-    const [fileError, setFileError] = React.useState<FileError>();
+    const [files, setFiles] = useState<FileWithPreview[]>([]);
+    const [fileError, setFileError] = useState<FileError>();
 
     const handleRemoveFile = (id: number) => {
       setFiles((previousFiles: FileWithPreview[]) =>
@@ -119,12 +120,12 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
     } = getInputProps();
 
     // HACK: Runs the `onChange` and `onBlur` functions and swaps in our local state whenever `files` is updated.
-    React.useEffect(() => {
+    useEffect(() => {
       onChange?.({ target: { value: files, name }, type: 'change' } as any);
       onBlur?.({ target: { value: files, name }, type: 'blur' } as any);
     }, [files, name, onBlur, onChange]);
 
-    React.useEffect(() => {
+    useEffect(() => {
       if (!fileRejections.length) {
         setFileError(undefined);
         return;

--- a/packages/modal-dialog/src/content-dialog.tsx
+++ b/packages/modal-dialog/src/content-dialog.tsx
@@ -14,7 +14,8 @@ import { XIcon } from '@spark-web/icon';
 import { Stack } from '@spark-web/stack';
 import type { BrighteTheme } from '@spark-web/theme';
 import { useTheme } from '@spark-web/theme';
-import * as React from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 const MAX_HEIGHT = '85vh';
 const CONTENT_PADDING = 'xlarge';
@@ -30,7 +31,7 @@ const hideOverlay = keyframes({
   to: { opacity: 1 },
 });
 
-const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps>(
+const DialogOverlay = forwardRef<HTMLDivElement, DialogOverlayProps>(
   (props, forwardedRef) => {
     const theme = useTheme();
     return (
@@ -64,7 +65,7 @@ DialogOverlay.displayName = 'DialogOverlay';
 // Dialog Content
 // ------------------------------
 
-const DialogContent = React.forwardRef<
+const DialogContent = forwardRef<
   HTMLDivElement,
   DialogContentProps & { size?: ContentDialogProps['size'] }
 >(({ children, size = 'small', ...rest }, forwardedRef) => {
@@ -226,7 +227,7 @@ export function DialogCloseButton(props: DialogCloseProps): JSX.Element {
 // Content Dialog
 // ------------------------------
 type ContentDialogProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   size?: keyof BrighteTheme['contentWidth'];
   title: string;
   description?: string;
@@ -234,12 +235,12 @@ type ContentDialogProps = {
   | {
       isOpen: boolean;
       onToggle: () => void;
-      trigger?: React.ReactNode;
+      trigger?: ReactNode;
     }
   | {
       isOpen?: never;
       onToggle?: never;
-      trigger: React.ReactNode;
+      trigger: ReactNode;
     }
 );
 

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -7,7 +7,8 @@ import { useInput } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import { buildDataAttributes } from '@spark-web/utils/internal';
-import * as React from 'react';
+import type { SelectHTMLAttributes } from 'react';
+import { forwardRef, useCallback } from 'react';
 
 type Option = {
   disabled?: boolean;
@@ -18,7 +19,7 @@ type Group = { options: Array<Option>; label: string };
 export type OptionsOrGroups = Array<Option | Group>;
 
 export type SelectProps = Pick<
-  React.SelectHTMLAttributes<HTMLSelectElement>,
+  SelectHTMLAttributes<HTMLSelectElement>,
   'defaultValue' | 'name' | 'onBlur' | 'onChange' | 'required' | 'value'
 > & {
   data?: DataAttributeMap;
@@ -26,7 +27,7 @@ export type SelectProps = Pick<
   placeholder?: string;
 };
 
-export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   (
     {
       data,
@@ -44,7 +45,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     const { disabled, invalid, ...a11yProps } = useFieldContext();
     const styles = useSelectStyles({ disabled, invalid });
 
-    const mapOptions = React.useCallback(
+    const mapOptions = useCallback(
       (opt: Option) => (
         <option key={opt.value} value={opt.value} disabled={opt.disabled}>
           {opt.label}

--- a/packages/utils/src/ts/forwardRefWithAs.ts
+++ b/packages/utils/src/ts/forwardRefWithAs.ts
@@ -45,7 +45,7 @@ export const forwardRefWithAs = <
 >(
   render: (
     props: BaseProps & { as?: ElementType },
-    ref: React.Ref<any>
+    ref: Ref<any>
   ) => Exclude<ReactNode, undefined>
 ): CompWithAsProp<BaseProps, DefaultElementType> => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/utils/src/ts/utility-types.ts
+++ b/packages/utils/src/ts/utility-types.ts
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import type { MutableRefObject } from 'react';
 
 /**
  * React.Ref uses the readonly type `React.RefObject` instead of
@@ -10,7 +10,7 @@ export type AssignableRef<ValueType> =
   | {
       bivarianceHack(instance: ValueType | null): void;
     }['bivarianceHack']
-  | React.MutableRefObject<ValueType | null>;
+  | MutableRefObject<ValueType | null>;
 
 /**
  * Type can be either a single `ValueType` or an array of `ValueType`


### PR DESCRIPTION
When Spark Web was in the energy monorepo, we had to use the Babel and ESLint configs that were already there. Neither was configured to let you omit the React import for hinting to Babel/SWC to use `React.createElement` on JSX.

Now that we've got a bit more control this has been fixed. We did a big pass of the codebase when we pulled it out so that we could tree-shake React code from the packages, but missed a few places. This is just finishing that work off.