### PR TITLE
Remove baseUrl and paths from docs tsconfig

### DIFF
--- a/docs/components/content/toc-context.tsx
+++ b/docs/components/content/toc-context.tsx
@@ -1,9 +1,9 @@
 import type { HeadingProps } from '@spark-web/heading';
 import { Heading as SparkHeading } from '@spark-web/heading';
-import { HEADER_HEIGHT } from 'components/constants';
 import type { ProviderProps } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 
+import { HEADER_HEIGHT } from '../../components/constants';
 import type { HeadingData } from '../../utils/generate-toc';
 import {
   IntersectionObserverProvider,

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -4,11 +4,11 @@ import { Strong, Text } from '@spark-web/text';
 import { TextLink } from '@spark-web/text-link';
 import type { TextListProps } from '@spark-web/text-list';
 import { TextList } from '@spark-web/text-list';
-import { Heading } from 'components/content/toc-context';
 import type { ReactNode } from 'react';
 import { Children, Fragment } from 'react';
 
 import * as sparkComponents from '../../cache/spark-components';
+import { Heading } from '../../components/content/toc-context';
 import { InlineCode } from '../example-helpers';
 import { CodeBlock } from './code-block';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';

--- a/docs/contentlayer.config.ts
+++ b/docs/contentlayer.config.ts
@@ -96,6 +96,7 @@ export const Package = defineDocumentType(() => ({
 export default makeSource({
   contentDirInclude: ['{docs/pages,packages}'],
   contentDirPath: '..',
+  disableImportAliasWarning: true,
   documentTypes: [Home, Package],
   mdx: {
     remarkPlugins: [remarkGfm],

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,10 +1,10 @@
 import { SparkProvider } from '@spark-web/core';
 import { UniversalNextLink } from '@spark-web/next-utils';
-import { allPackages } from 'contentlayer/generated';
 import type { AppProps } from 'next/app';
 import NextHead from 'next/head';
 import { DefaultSeo } from 'next-seo';
 
+import { allPackages } from '../.contentlayer/generated';
 import { Layout } from '../components/layout';
 import type { SidebarNavItemType } from '../components/sidebar';
 

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,9 +1,9 @@
 import { Stack } from '@spark-web/stack';
-import { MDXContent } from 'components/mdx-components/mdx-content';
-import { home } from 'contentlayer/generated';
 import type { GetStaticProps, InferGetStaticPropsType } from 'next';
 
+import { home } from '../.contentlayer/generated';
 import { DocsContent } from '../components/content';
+import { MDXContent } from '../components/mdx-components/mdx-content';
 import type { HeadingData } from '../utils/generate-toc';
 
 export const getStaticProps: GetStaticProps<{

--- a/docs/pages/package/[slug].tsx
+++ b/docs/pages/package/[slug].tsx
@@ -8,10 +8,6 @@ import { Link } from '@spark-web/link';
 import { Stack } from '@spark-web/stack';
 import { Text } from '@spark-web/text';
 import { TextLink } from '@spark-web/text-link';
-import { GITHUB_URL } from 'components/constants';
-import { InlineCode } from 'components/example-helpers';
-import { MDXContent } from 'components/mdx-components/mdx-content';
-import { allPackages } from 'contentlayer/generated';
 import type {
   GetStaticPaths,
   GetStaticProps,
@@ -19,7 +15,11 @@ import type {
 } from 'next';
 import { createElement } from 'react';
 
+import { allPackages } from '../../.contentlayer/generated';
+import { GITHUB_URL } from '../../components/constants';
 import { DocsContent } from '../../components/content';
+import { InlineCode } from '../../components/example-helpers';
+import { MDXContent } from '../../components/mdx-components/mdx-content';
 import { StorybookIcon } from '../../components/vectors/fill';
 import type { HeadingData } from '../../utils/generate-toc';
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
@@ -12,7 +11,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
-    "paths": { "contentlayer/generated": ["./.contentlayer/generated"] },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
When we added the path alias for contentlayer to our tsconfig it made it so that automatic imports from VSCode were no longer relative.
This makes it less clear if an import is a local file or an installed dependency and leads to inconsistent imports.