### PR TITLE
Fix alignment of icon adornments

### DIFF
--- a/.changeset/afraid-worms-tap.md
+++ b/.changeset/afraid-worms-tap.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/text-input': patch
+---
+
+Fix alignment of icon adornments

--- a/packages/text-input/src/InputAdornment.tsx
+++ b/packages/text-input/src/InputAdornment.tsx
@@ -79,6 +79,7 @@ export const InputAdornment = ({
           dimensions.
         */}
         <Box
+          display="flex"
           alignItems="center"
           justifyContent="center"
           style={{ minWidth: sizing.xxsmall }}


### PR DESCRIPTION
Before:

![PixelSnap 2022-05-16 at 10 30 57@2x](https://user-images.githubusercontent.com/3422401/168501416-d6ebbc59-508f-435b-af64-b960b24ebfbb.png)


After:

![PixelSnap 2022-05-16 at 10 31 33@2x](https://user-images.githubusercontent.com/3422401/168501439-bf7a0c7a-d98d-4829-9710-771bc7cf15d8.png)
