### PR TITLE
Add aria-invalid attribute to field items

### DIFF
--- a/.changeset/angry-boats-cough.md
+++ b/.changeset/angry-boats-cough.md
@@ -1,0 +1,7 @@
+---
+'@spark-web/combobox': patch
+'@spark-web/select': patch
+'@spark-web/text-input': patch
+---
+
+Add aria-invalid attribute

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -71,6 +71,7 @@ export const Combobox = <Item,>({
   return (
     <ReactSelect<Item>
       aria-describedby={ariaDescribedBy}
+      aria-invalid={invalid || undefined}
       components={reactSelectComponentsOverride}
       inputId={inputId}
       inputValue={inputValue}

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -57,8 +57,9 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       <Box position="relative">
         <Box
           {...a11yProps}
-          data={data}
+          aria-invalid={invalid || undefined}
           as="select"
+          data={data}
           defaultValue={defaultValue ?? placeholder ? '' : undefined}
           disabled={disabled}
           name={name}

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -80,6 +80,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         {startAdornment}
         <Box
           as="input"
+          aria-invalid={invalid || undefined}
           ref={forwardedRef}
           disabled={disabled}
           // Styles


### PR DESCRIPTION
The `FieldContext` provides an invalid boolean.
Currently this is only being used for styling. This PR uses it to mark the components that consume this context as invalid.