### PR TITLE
Update focus and disabled styles for form elements

### DIFF
--- a/.changeset/empty-birds-flash.md
+++ b/.changeset/empty-birds-flash.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/a11y': patch
+---
+
+Make focus styles more accessible for Windows High Contrast users

--- a/.changeset/three-squids-accept.md
+++ b/.changeset/three-squids-accept.md
@@ -1,0 +1,6 @@
+---
+'@spark-web/select': patch
+'@spark-web/text-area': patch
+---
+
+Update focus and disabled styles

--- a/.changeset/tiny-bananas-doubt.md
+++ b/.changeset/tiny-bananas-doubt.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/text-input': minor
+---
+
+Create FocusIndicator component and update focus styles

--- a/.changeset/tiny-bananas-doubt.md
+++ b/.changeset/tiny-bananas-doubt.md
@@ -2,4 +2,4 @@
 '@spark-web/text-input': minor
 ---
 
-Create FocusIndicator component and update focus and disabled styles
+Create InputContainer component and update focus and disabled styles

--- a/.changeset/tiny-bananas-doubt.md
+++ b/.changeset/tiny-bananas-doubt.md
@@ -2,4 +2,4 @@
 '@spark-web/text-input': minor
 ---
 
-Create FocusIndicator component and update focus styles
+Create FocusIndicator component and update focus and disabled styles

--- a/packages/a11y/src/focusRing.ts
+++ b/packages/a11y/src/focusRing.ts
@@ -71,7 +71,15 @@ export const useFocusRing = ({
   };
 
   return {
-    outline: 0,
+    /**
+     * This removes the nested input outline visibility since
+     * the wrapper will be outlined, but still visibly focusable
+     * to windows high contrast mode users.
+     *
+     * @see https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors
+     */
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
     ...(always
       ? styles
       : {

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -3,7 +3,7 @@ import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
 import type { UseInputProps } from '@spark-web/text-input';
-import { FocusIndicator, useInput } from '@spark-web/text-input';
+import { InputContainer, useInput } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { SelectHTMLAttributes } from 'react';
@@ -54,10 +54,19 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     );
 
     return (
-      <Box
-        position="relative"
-        background={disabled ? 'inputDisabled' : 'input'}
-      >
+      <InputContainer>
+        <Box
+          position="absolute"
+          top={0}
+          bottom={0}
+          right={0}
+          display="flex"
+          alignItems="center"
+          padding="medium"
+          className={css({ pointerEvents: 'none' })}
+        >
+          <ChevronDownIcon size="xxsmall" tone="placeholder" />
+        </Box>
         <Box
           {...a11yProps}
           aria-invalid={invalid || undefined}
@@ -96,20 +105,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             return mapOptions(optionOrGroup);
           })}
         </Box>
-        <FocusIndicator invalid={invalid} />
-        <Box
-          position="absolute"
-          top={0}
-          bottom={0}
-          right={0}
-          display="flex"
-          alignItems="center"
-          padding="medium"
-          className={css({ pointerEvents: 'none' })}
-        >
-          <ChevronDownIcon size="xxsmall" tone="placeholder" />
-        </Box>
-      </Box>
+      </InputContainer>
     );
   }
 );

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -3,7 +3,7 @@ import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
 import type { UseInputProps } from '@spark-web/text-input';
-import { useInput } from '@spark-web/text-input';
+import { FocusIndicator, useInput } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { SelectHTMLAttributes } from 'react';
@@ -54,7 +54,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     );
 
     return (
-      <Box position="relative">
+      <Box
+        position="relative"
+        background={disabled ? 'inputDisabled' : 'input'}
+      >
         <Box
           {...a11yProps}
           aria-invalid={invalid || undefined}
@@ -93,6 +96,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             return mapOptions(optionOrGroup);
           })}
         </Box>
+        <FocusIndicator invalid={invalid} />
         <Box
           position="absolute"
           top={0}

--- a/packages/text-area/src/text-area.tsx
+++ b/packages/text-area/src/text-area.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
+import { FocusIndicator } from '@spark-web/text-input';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { TextareaHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
@@ -48,12 +49,16 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const textAreaStyles = useTextAreaStyles({ disabled, invalid });
 
     return (
-      <Box position="relative">
+      <Box
+        position="relative"
+        background={disabled ? 'inputDisabled' : 'input'}
+      >
         <Box
           {...a11yProps}
           {...consumerProps}
-          data={data}
           as="textarea"
+          aria-invalid={invalid || undefined}
+          data={data}
           ref={forwardedRef}
           rows={3}
           // Styles
@@ -65,6 +70,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           width="full"
           className={css(textAreaStyles)}
         />
+        <FocusIndicator invalid={invalid} />
       </Box>
     );
   }

--- a/packages/text-area/src/text-area.tsx
+++ b/packages/text-area/src/text-area.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
-import { FocusIndicator } from '@spark-web/text-input';
+import { InputContainer } from '@spark-web/text-input';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { TextareaHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
@@ -49,10 +49,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const textAreaStyles = useTextAreaStyles({ disabled, invalid });
 
     return (
-      <Box
-        position="relative"
-        background={disabled ? 'inputDisabled' : 'input'}
-      >
+      <InputContainer>
         <Box
           {...a11yProps}
           {...consumerProps}
@@ -70,8 +67,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           width="full"
           className={css(textAreaStyles)}
         />
-        <FocusIndicator invalid={invalid} />
-      </Box>
+      </InputContainer>
     );
   }
 );

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,16 +1,18 @@
 import { css } from '@emotion/css';
 import { useFocusRing } from '@spark-web/a11y';
+import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import type { FieldContextType } from '@spark-web/field';
 import { useFieldContext } from '@spark-web/field';
 import { useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import type { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes, ReactElement } from 'react';
 import { forwardRef } from 'react';
 
 import type { AdornmentsAsChildren } from './childrenToAdornments';
 import { childrenToAdornments } from './childrenToAdornments';
+import type { InputAdornmentProps } from './InputAdornment';
 
 type ValidTypes =
   | 'text'
@@ -66,13 +68,12 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const { startAdornment, endAdornment } = childrenToAdornments(children);
 
     return (
-      <Box
+      <InputContainer
         display="inline-flex"
         alignItems="center"
-        position="relative"
-        background={disabled ? 'inputDisabled' : 'input'}
+        startAdornment={startAdornment}
+        endAdornment={endAdornment}
       >
-        {startAdornment}
         <Box
           as="input"
           aria-invalid={invalid || undefined}
@@ -90,33 +91,12 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           {...a11yProps}
           {...consumerProps}
         />
-        <FocusIndicator invalid={invalid} />
-        {endAdornment}
-      </Box>
+      </InputContainer>
     );
   }
 );
 
 TextInput.displayName = 'TextInput';
-
-export const FocusIndicator = ({ invalid }: { invalid: boolean }) => {
-  return (
-    <Box
-      aria-hidden="true"
-      as="span"
-      data={{ 'focus-indicator': 'true' }}
-      // Styles
-      border={invalid ? 'critical' : 'field'}
-      borderRadius="small"
-      position="absolute"
-      bottom={0}
-      left={0}
-      right={0}
-      top={0}
-      className={css({ pointerEvents: 'none' })}
-    />
-  );
-};
 
 export type UseInputProps = Pick<FieldContextType, 'disabled' | 'invalid'>;
 
@@ -143,4 +123,50 @@ export const useInput = ({ disabled }: UseInputProps) => {
       },
     },
   } as const;
+};
+
+export type InputContainerProps = {
+  startAdornment?: ReactElement<InputAdornmentProps> | null;
+  endAdornment?: ReactElement<InputAdornmentProps> | null;
+} & Omit<BoxProps, 'background' | 'position'>;
+
+export const InputContainer = ({
+  children,
+  startAdornment,
+  endAdornment,
+  ...boxProps
+}: InputContainerProps) => {
+  const { disabled, invalid } = useFieldContext();
+
+  return (
+    <Box
+      position="relative"
+      background={disabled ? 'inputDisabled' : 'input'}
+      {...boxProps}
+    >
+      {startAdornment}
+      {children}
+      <FocusIndicator invalid={invalid} />
+      {endAdornment}
+    </Box>
+  );
+};
+
+const FocusIndicator = ({ invalid }: { invalid: boolean }) => {
+  return (
+    <Box
+      aria-hidden="true"
+      as="span"
+      data={{ 'focus-indicator': 'true' }}
+      // Styles
+      border={invalid ? 'critical' : 'field'}
+      borderRadius="small"
+      position="absolute"
+      bottom={0}
+      left={0}
+      right={0}
+      top={0}
+      className={css({ pointerEvents: 'none' })}
+    />
+  );
 };

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -67,45 +67,60 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     return (
       <Box
-        background={disabled ? 'inputDisabled' : 'input'}
-        border={invalid ? 'critical' : 'field'}
-        borderRadius="small"
         display="inline-flex"
         alignItems="center"
-        flexDirection="row"
-        height="medium"
-        marginY="none"
-        className={css(useInput({ disabled, invalid }))}
+        position="relative"
+        background={disabled ? 'inputDisabled' : 'input'}
       >
         {startAdornment}
         <Box
           as="input"
           aria-invalid={invalid || undefined}
           ref={forwardedRef}
+          data={data}
           disabled={disabled}
+          position="relative"
           // Styles
           flex={1}
           height="medium"
           paddingX="medium"
           paddingLeft={startAdornment ? 'none' : 'medium'}
           paddingRight={endAdornment ? 'none' : 'medium'}
-          className={css(useInput({ disabled, invalid, isNested: true }))}
-          data={data}
+          className={css(useInput({ disabled, invalid }))}
           {...a11yProps}
           {...consumerProps}
         />
+        <FocusIndicator invalid={invalid} />
         {endAdornment}
       </Box>
     );
   }
 );
+
 TextInput.displayName = 'TextInput';
 
-export type UseInputProps = Pick<FieldContextType, 'disabled' | 'invalid'> & {
-  isNested?: boolean;
+export const FocusIndicator = ({ invalid }: { invalid: boolean }) => {
+  return (
+    <Box
+      aria-hidden="true"
+      as="span"
+      data={{ 'focus-indicator': 'true' }}
+      // Styles
+      border={invalid ? 'critical' : 'field'}
+      borderRadius="small"
+      position="absolute"
+      bottom={0}
+      left={0}
+      right={0}
+      top={0}
+      className={css({ pointerEvents: 'none' })}
+    />
+  );
 };
 
-export const useInput = ({ disabled, isNested = false }: UseInputProps) => {
+export type UseInputProps = Pick<FieldContextType, 'disabled' | 'invalid'>;
+
+export const useInput = ({ disabled }: UseInputProps) => {
   const theme = useTheme();
   const focusRingStyles = useFocusRing({ always: true });
   const textStyles = useText({
@@ -120,28 +135,12 @@ export const useInput = ({ disabled, isNested = false }: UseInputProps) => {
   return {
     ...typographyStyles,
     ...responsiveStyles,
-    ...(isNested
-      ? {
-          ':focus': {
-            // This removes the nested input outline visibility since
-            // the wrapper will be outlined, but still visibly focusable
-            // to windows high contrast mode users.
-            // @see https://tailwindcss.com/docs/outline-style#removing-outlines
-            outline: '2px solid transparent',
-            outlineOffset: '2px',
-          },
-        }
-      : {
-          ':enabled': {
-            '&:focus': {
-              ...focusRingStyles,
-              borderColor: theme.border.color.fieldAccent,
-            },
-          },
-          ':focus-within': {
-            ...focusRingStyles,
-            borderColor: theme.border.color.fieldAccent,
-          },
-        }),
+    ':focus': { outline: 'none' },
+    ':enabled': {
+      ':focus + [data-focus-indicator]': {
+        borderColor: theme.border.color.fieldAccent,
+        ...focusRingStyles,
+      },
+    },
   } as const;
 };

--- a/packages/text-input/src/index.ts
+++ b/packages/text-input/src/index.ts
@@ -1,7 +1,11 @@
 export { InputAdornment } from './InputAdornment';
-export { FocusIndicator, TextInput, useInput } from './TextInput';
+export { InputContainer, TextInput, useInput } from './TextInput';
 
 // types
 
 export type { AdornmentChild } from './childrenToAdornments';
-export type { TextInputProps, UseInputProps } from './TextInput';
+export type {
+  InputContainerProps,
+  TextInputProps,
+  UseInputProps,
+} from './TextInput';

--- a/packages/text-input/src/index.ts
+++ b/packages/text-input/src/index.ts
@@ -1,5 +1,5 @@
 export { InputAdornment } from './InputAdornment';
-export { TextInput, useInput } from './TextInput';
+export { FocusIndicator, TextInput, useInput } from './TextInput';
 
 // types
 


### PR DESCRIPTION
One thing that we considered when designing our inputs is that password managers like to insert their icons _inside_ of the inputs. This can overlap with adornments (buttons/icons etc) so we are careful to wrap our inputs in an element that wraps both the input and adornments and fakes the focus ring. This way the input sits beside the adornment instead of of the adornment being absolutely positioned above the input.

Previously we were using the :focus-within` pseudo-class to apply the focus ring to the wrapper div whenever any child had focus, however, this causes double focus rings when we focus on the adornment (for things like the [PasswordInput](https://github.com/brighte-labs/spark-web/pull/90)).

The way I've come up with to address this is to stop using `:focus-within` and instead style an absolutely positioned adjacent sibling whenever the input has focus. This does mean that we need to export a component that sits beside our inputs to be styled. I tried styling a `::before` pseudo element so we didn't need to extra element, but I couldn't get it to work. I'm not 100% sure why, but I think it's because inputs are treated as 'replaced' elements and so the `::before` and `::after` don't work on them.

Here's some screenshots of what it looks like in action:

Adornment and 1Password icon sitting beside each other
![PixelSnap 2022-05-18 at 10 53 49@2x](https://user-images.githubusercontent.com/3422401/168935344-43bb8e9b-3aa8-4c17-b28a-b248e8404b38.png)

Adornment focused, no focus ring on input
![PixelSnap 2022-05-18 at 10 54 33@2x](https://user-images.githubusercontent.com/3422401/168935387-df94cf04-591f-4a08-8d28-0bda8181a8d2.png)
