### PR TITLE
Fix TextInput type

### DIFF
--- a/.changeset/slimy-spiders-sell.md
+++ b/.changeset/slimy-spiders-sell.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/text-input': patch
+---
+
+Fix TextInput type

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -6,7 +6,7 @@ import { useFieldContext } from '@spark-web/field';
 import { useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import type { AllHTMLAttributes } from 'react';
+import type { InputHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
 import type { AdornmentsAsChildren } from './childrenToAdornments';
@@ -31,7 +31,7 @@ type ValidModes =
   | 'search';
 
 type NativeInputProps = Pick<
-  AllHTMLAttributes<HTMLInputElement>,
+  InputHTMLAttributes<HTMLInputElement>,
   | 'name'
   | 'onBlur'
   | 'onChange'


### PR DESCRIPTION
# Description

Change `<TextInput/>` native prop types to match `<input/>`

# Checklist:

- [x] I've updated unit tests where needed
- [x] I've updated the components README.md where needed
- [x] I've added major version bumps for my breaking changes
- [x] I've added changesets where needed
- [x] All the components I've updated are reflected in the changelog
