### PR TITLE
Move InputContainer to it's own file and document it

### DIFF
--- a/packages/password-input/src/PasswordInput.tsx
+++ b/packages/password-input/src/PasswordInput.tsx
@@ -14,7 +14,7 @@ export type PasswordInputProps = Omit<TextInputProps, 'children' | 'inputMode'>;
 
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   (props, forwardedRef) => {
-    const { disabled } = useFieldContext();
+    const [{ disabled }] = useFieldContext();
     const [showPassword, setShowPassword] = useState(false);
 
     const toggleShowPassword = () => setShowPassword(!showPassword);

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -7,7 +7,7 @@ Text input provides a way for inputting text. The component must be nested
 within a [`Field`](/package/field). See [`Field`](/package/field) for more
 details.
 
-## Examples
+## Text Input
 
 ### Controlled
 
@@ -76,7 +76,28 @@ return (
 );
 ```
 
+## InputContainer
+
+The `InputContainer` is used internally to handle some shared styling between
+components that are wrapped in the `Field` component.
+
+Typically input adornments (icons or buttons that _appear_ to be inside the
+input) will be absolutely positioning on above it and padding is applied to make
+sure that text does not get obscured below the adornments.
+
+On top of this, password managers will insert buttons above the input which can
+get in the way of our adornments.
+
+To get around these problems, we wrap the input and adornments with the
+`InputContainer` and apply our own focus styles to an absolutely positioned
+element that is an adjacent sibling of the input (when the input is focused).
+
+The `InputContainer` also provides the border and background styles and has
+slots to place the start and end adornments.
+
 ## Props
+
+### TextInput
 
 | Prop         | Type                                                                                | Default | Description                                                                                  |
 | ------------ | ----------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
@@ -94,3 +115,12 @@ return (
   https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1
 [adornment-children]:
   https://github.com/brighte-labs/spark-web/blob/d4da46200f2d6e5e9291d3c650eaaff7e53f411b/packages/text-input/src/childrenToAdornments.tsx#L12
+
+### InputContainer
+
+| Prop            | Type                               | Default | Description |
+| --------------- | ---------------------------------- | ------- | ----------- | --- |
+| startAdornment? | ReactElement\<InputAdornmentProps> |         |             |     |
+| endAdornment?   | ReactElement\<InputAdornmentProps> |         |             |     |
+
+Extra props are passed into the underlying [`Box`](/package/box) component.

--- a/packages/text-input/src/InputContainer.tsx
+++ b/packages/text-input/src/InputContainer.tsx
@@ -17,7 +17,7 @@ export const InputContainer = ({
   endAdornment,
   ...boxProps
 }: InputContainerProps) => {
-  const { disabled, invalid } = useFieldContext();
+  const [{ disabled, invalid }] = useFieldContext();
 
   return (
     <Box

--- a/packages/text-input/src/InputContainer.tsx
+++ b/packages/text-input/src/InputContainer.tsx
@@ -1,0 +1,53 @@
+import { css } from '@emotion/css';
+import type { BoxProps } from '@spark-web/box';
+import { Box } from '@spark-web/box';
+import { useFieldContext } from '@spark-web/field';
+import type { ReactElement } from 'react';
+
+import type { InputAdornmentProps } from './InputAdornment';
+
+export type InputContainerProps = {
+  startAdornment?: ReactElement<InputAdornmentProps> | null;
+  endAdornment?: ReactElement<InputAdornmentProps> | null;
+} & Omit<BoxProps, 'background' | 'position'>;
+
+export const InputContainer = ({
+  children,
+  startAdornment,
+  endAdornment,
+  ...boxProps
+}: InputContainerProps) => {
+  const { disabled, invalid } = useFieldContext();
+
+  return (
+    <Box
+      position="relative"
+      background={disabled ? 'inputDisabled' : 'input'}
+      {...boxProps}
+    >
+      {startAdornment}
+      {children}
+      <FocusIndicator invalid={invalid} />
+      {endAdornment}
+    </Box>
+  );
+};
+
+const FocusIndicator = ({ invalid }: { invalid: boolean }) => {
+  return (
+    <Box
+      aria-hidden="true"
+      as="span"
+      data={{ 'focus-indicator': 'true' }}
+      // Styles
+      border={invalid ? 'critical' : 'field'}
+      borderRadius="small"
+      position="absolute"
+      bottom={0}
+      left={0}
+      right={0}
+      top={0}
+      className={css({ pointerEvents: 'none' })}
+    />
+  );
+};

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,18 +1,17 @@
 import { css } from '@emotion/css';
 import { useFocusRing } from '@spark-web/a11y';
-import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import type { FieldState } from '@spark-web/field';
 import { useFieldContext } from '@spark-web/field';
 import { useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import type { InputHTMLAttributes, ReactElement } from 'react';
+import type { InputHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
 import type { AdornmentsAsChildren } from './childrenToAdornments';
 import { childrenToAdornments } from './childrenToAdornments';
-import type { InputAdornmentProps } from './InputAdornment';
+import { InputContainer } from './InputContainer';
 
 type ValidTypes =
   | 'text'
@@ -122,50 +121,4 @@ export const useInput = ({ disabled }: UseInputProps) => {
       },
     },
   } as const;
-};
-
-export type InputContainerProps = {
-  startAdornment?: ReactElement<InputAdornmentProps> | null;
-  endAdornment?: ReactElement<InputAdornmentProps> | null;
-} & Omit<BoxProps, 'background' | 'position'>;
-
-export const InputContainer = ({
-  children,
-  startAdornment,
-  endAdornment,
-  ...boxProps
-}: InputContainerProps) => {
-  const [{ disabled, invalid }] = useFieldContext();
-
-  return (
-    <Box
-      position="relative"
-      background={disabled ? 'inputDisabled' : 'input'}
-      {...boxProps}
-    >
-      {startAdornment}
-      {children}
-      <FocusIndicator invalid={invalid} />
-      {endAdornment}
-    </Box>
-  );
-};
-
-const FocusIndicator = ({ invalid }: { invalid: boolean }) => {
-  return (
-    <Box
-      aria-hidden="true"
-      as="span"
-      data={{ 'focus-indicator': 'true' }}
-      // Styles
-      border={invalid ? 'critical' : 'field'}
-      borderRadius="small"
-      position="absolute"
-      bottom={0}
-      left={0}
-      right={0}
-      top={0}
-      className={css({ pointerEvents: 'none' })}
-    />
-  );
 };

--- a/packages/text-input/src/index.ts
+++ b/packages/text-input/src/index.ts
@@ -1,11 +1,9 @@
 export { InputAdornment } from './InputAdornment';
-export { InputContainer, TextInput, useInput } from './TextInput';
+export { InputContainer } from './InputContainer';
+export { TextInput, useInput } from './TextInput';
 
 // types
 
 export type { AdornmentChild } from './childrenToAdornments';
-export type {
-  InputContainerProps,
-  TextInputProps,
-  UseInputProps,
-} from './TextInput';
+export type { InputContainerProps } from './InputContainer';
+export type { TextInputProps, UseInputProps } from './TextInput';


### PR DESCRIPTION
This PR moves the `InputContainer` into it's own file and adds docs for what it is, and how to use it.

I haven't added a changeset for this, as it will just add noise to the changelog (since we haven't published a release since the `InputContainer` was added). The API hasn't changed, so it would just be a patch.