### PR TITLE
Refactor useFieldContext to return tuple

### DIFF
--- a/.changeset/mighty-kiwis-reply.md
+++ b/.changeset/mighty-kiwis-reply.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/field': major
+---
+
+Refactor useFieldContext to return tuple

--- a/.changeset/three-tomatoes-kick.md
+++ b/.changeset/three-tomatoes-kick.md
@@ -1,0 +1,10 @@
+---
+'@spark-web/combobox': patch
+'@spark-web/currency-input': patch
+'@spark-web/dropzone': patch
+'@spark-web/select': patch
+'@spark-web/text-area': patch
+'@spark-web/text-input': patch
+---
+
+Refactor to work with updated field context

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -68,12 +68,8 @@ export const Combobox = <Item,>({
   getOptionValue,
   value,
 }: ComboboxProps<Item>) => {
-  const {
-    disabled,
-    invalid,
-    id: inputId,
-    'aria-describedby': ariaDescribedBy,
-  } = useFieldContext();
+  const [{ disabled, invalid }, { id: inputId, ...a11yProps }] =
+    useFieldContext();
 
   const stylesOverride = useReactSelectStylesOverride<Item>({ invalid });
   const themeOverride = useReactSelectThemeOverride();
@@ -82,8 +78,7 @@ export const Combobox = <Item,>({
 
   return (
     <ReactSelect<Item>
-      aria-describedby={ariaDescribedBy}
-      aria-invalid={invalid || undefined}
+      {...a11yProps}
       components={reactSelectComponentsOverride}
       inputId={inputId}
       inputValue={inputValue}

--- a/packages/currency-input/src/CurrencyInput.tsx
+++ b/packages/currency-input/src/CurrencyInput.tsx
@@ -21,7 +21,7 @@ export type CurrencyInputProps = {
 /** A component for inputting numbers into the app via a keyboard. Enforces 2 fraction digits. */
 export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
   ({ currencyType, data, ...props }, forwardedRef) => {
-    const { disabled } = useFieldContext();
+    const [{ disabled }] = useFieldContext();
 
     const { onChange, value, ...rest } = props;
 

--- a/packages/dropzone/src/dropzone.tsx
+++ b/packages/dropzone/src/dropzone.tsx
@@ -85,7 +85,7 @@ export const Dropzone = forwardRef<HTMLInputElement, DropzoneProps>(
       setFiles(prevFiles => [...prevFiles, ...acceptedFilesWithPreview]);
     };
 
-    const { disabled, invalid, ...a11yProps } = useFieldContext();
+    const [{ disabled, invalid }, a11yProps] = useFieldContext();
 
     const {
       fileRejections,
@@ -183,7 +183,6 @@ export const Dropzone = forwardRef<HTMLInputElement, DropzoneProps>(
       <Stack gap="large">
         <VisuallyHidden
           as="input"
-          aria-invalid={invalid}
           disabled={disabled}
           name={name}
           onBlur={onBlur}

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -10,6 +10,7 @@ import { buildDataAttributes } from '@spark-web/utils/internal';
 import type { ReactElement, ReactNode } from 'react';
 import { forwardRef, Fragment } from 'react';
 
+import type { FieldContextType } from './context';
 import { FieldContextProvider } from './context';
 
 export type Tone = keyof typeof messageToneMap;
@@ -69,15 +70,18 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
     const { descriptionId, inputId, messageId } = useFieldIds(idProp);
 
     // field context
-    const fieldContext = {
-      'aria-describedby': mergeIds(
-        message && messageId,
-        description && descriptionId
-      ),
-      id: inputId,
-      disabled,
-      invalid: Boolean(message && tone === 'critical'),
-    };
+    const invalid = Boolean(message && tone === 'critical');
+    const fieldContext: FieldContextType = [
+      { disabled, invalid },
+      {
+        'aria-describedby': mergeIds(
+          message && messageId,
+          description && descriptionId
+        ),
+        'aria-invalid': invalid || undefined,
+        id: inputId,
+      },
+    ];
 
     // label prep
     const hiddenLabel = (

--- a/packages/field/src/context.ts
+++ b/packages/field/src/context.ts
@@ -1,11 +1,17 @@
 import { createContext, useContext } from 'react';
 
-export type FieldContextType = {
-  'aria-describedby'?: string;
-  id: string;
+type FieldState = {
   disabled: boolean;
   invalid: boolean;
 };
+
+type InputPropsDerivedFromField = {
+  'aria-describedby'?: string;
+  'aria-invalid': true | undefined;
+  id: string;
+};
+
+export type FieldContextType = [FieldState, InputPropsDerivedFromField];
 
 export const FieldContext = createContext<FieldContextType | null>(null);
 export const FieldContextProvider = FieldContext.Provider;

--- a/packages/field/src/context.ts
+++ b/packages/field/src/context.ts
@@ -1,11 +1,11 @@
 import { createContext, useContext } from 'react';
 
-type FieldState = {
+export type FieldState = {
   disabled: boolean;
   invalid: boolean;
 };
 
-type InputPropsDerivedFromField = {
+export type InputPropsDerivedFromField = {
   'aria-describedby'?: string;
   'aria-invalid': true | undefined;
   id: string;

--- a/packages/field/src/index.ts
+++ b/packages/field/src/index.ts
@@ -3,5 +3,9 @@ export { Field, FieldMessage, useFieldIds } from './Field';
 
 // types
 
-export type { FieldContextType } from './context';
+export type {
+  FieldContextType,
+  FieldState,
+  InputPropsDerivedFromField,
+} from './context';
 export type { FieldProps, Tone } from './Field';

--- a/packages/select/src/Select.test.tsx
+++ b/packages/select/src/Select.test.tsx
@@ -41,11 +41,13 @@ const renderComponent = ({
 describe('Select component', () => {
   const name = 'test select';
   beforeEach(() => {
-    useFieldContextMock.mockReturnValue({
-      disabled: false,
-      invalid: false,
-      'aria-label': name,
-    });
+    useFieldContextMock.mockReturnValue([
+      {
+        disabled: false,
+        invalid: false,
+      },
+      { 'aria-label': name },
+    ]);
   });
 
   afterEach(cleanup);
@@ -104,11 +106,13 @@ describe('Select component', () => {
   });
 
   it('should be disabled by field context', () => {
-    useFieldContextMock.mockReturnValue({
-      disabled: true,
-      invalid: true,
-      'aria-label': name,
-    });
+    useFieldContextMock.mockReturnValue([
+      {
+        disabled: true,
+        invalid: true,
+      },
+      { 'aria-label': name },
+    ]);
     renderComponent({ name, options: [] });
     expect(screen.getByLabelText(name)).toBeDisabled();
   });

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -41,7 +41,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     },
     forwardedRef
   ) => {
-    const { disabled, invalid, ...a11yProps } = useFieldContext();
+    const [{ disabled, invalid }, a11yProps] = useFieldContext();
     const styles = useSelectStyles({ disabled, invalid });
 
     const mapOptions = useCallback(
@@ -69,7 +69,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         </Box>
         <Box
           {...a11yProps}
-          aria-invalid={invalid || undefined}
           as="select"
           data={data}
           defaultValue={defaultValue ?? placeholder ? '' : undefined}

--- a/packages/text-area/src/text-area.tsx
+++ b/packages/text-area/src/text-area.tsx
@@ -35,7 +35,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     forwardedRef
   ) => {
-    const { disabled, invalid, ...a11yProps } = useFieldContext();
+    const [{ disabled, invalid }, a11yProps] = useFieldContext();
     const consumerProps = {
       value,
       defaultValue,
@@ -51,10 +51,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <InputContainer>
         <Box
-          {...a11yProps}
           {...consumerProps}
+          {...a11yProps}
           as="textarea"
-          aria-invalid={invalid || undefined}
           data={data}
           ref={forwardedRef}
           rows={3}

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useFocusRing } from '@spark-web/a11y';
 import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
-import type { FieldContextType } from '@spark-web/field';
+import type { FieldState } from '@spark-web/field';
 import { useFieldContext } from '@spark-web/field';
 import { useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
@@ -97,7 +97,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
 TextInput.displayName = 'TextInput';
 
-export type UseInputProps = Pick<FieldContextType[0], 'disabled' | 'invalid'>;
+export type UseInputProps = FieldState;
 
 export const useInput = ({ disabled }: UseInputProps) => {
   const theme = useTheme();

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -64,7 +64,7 @@ export type TextInputProps = {
 /** Organize and emphasize information quickly and effectively in a list of text elements. */
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   ({ children, data, ...consumerProps }, forwardedRef) => {
-    const { disabled, invalid, ...a11yProps } = useFieldContext();
+    const [{ disabled, invalid }, a11yProps] = useFieldContext();
     const { startAdornment, endAdornment } = childrenToAdornments(children);
 
     return (
@@ -75,8 +75,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         endAdornment={endAdornment}
       >
         <Box
+          {...consumerProps}
+          {...a11yProps}
           as="input"
-          aria-invalid={invalid || undefined}
           ref={forwardedRef}
           data={data}
           disabled={disabled}
@@ -88,8 +89,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           paddingLeft={startAdornment ? 'none' : 'medium'}
           paddingRight={endAdornment ? 'none' : 'medium'}
           className={css(useInput({ disabled, invalid }))}
-          {...a11yProps}
-          {...consumerProps}
         />
       </InputContainer>
     );
@@ -98,7 +97,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
 TextInput.displayName = 'TextInput';
 
-export type UseInputProps = Pick<FieldContextType, 'disabled' | 'invalid'>;
+export type UseInputProps = Pick<FieldContextType[0], 'disabled' | 'invalid'>;
 
 export const useInput = ({ disabled }: UseInputProps) => {
   const theme = useTheme();
@@ -136,7 +135,7 @@ export const InputContainer = ({
   endAdornment,
   ...boxProps
 }: InputContainerProps) => {
-  const { disabled, invalid } = useFieldContext();
+  const [{ disabled, invalid }] = useFieldContext();
 
   return (
     <Box


### PR DESCRIPTION
# Description

This PR addresses some feedback from Joss:
https://github.com/brighte-labs/spark-web/pull/101#discussion_r876582101
It refactors the `useFieldContext` hook to return a tuple of state and derived props and adds `aria-invalid`.

# Checklist:

- [x] I've updated unit tests where needed
- [x] I've updated the components README.md where needed
- [x] I've added major version bumps for my breaking changes
- [x] I've added changesets where needed
- [x] All the components I've updated are reflected in the changelog
