### PR TITLE
Update InputContainer docs

### DIFF
--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -118,9 +118,9 @@ slots to place the start and end adornments.
 
 ### InputContainer
 
-| Prop            | Type                               | Default | Description |
-| --------------- | ---------------------------------- | ------- | ----------- | --- |
-| startAdornment? | ReactElement\<InputAdornmentProps> |         |             |     |
-| endAdornment?   | ReactElement\<InputAdornmentProps> |         |             |     |
+| Prop            | Type                                | Default | Description                     |
+| --------------- | ----------------------------------- | ------- | ------------------------------- |
+| startAdornment? | ReactElement\<InputAdornmentProps\> |         | Slot to start render adornment. |
+| endAdornment?   | ReactElement\<InputAdornmentProps\> |         | Slot to end render adornment.   |
 
 Extra props are passed into the underlying [`Box`](/package/box) component.

--- a/packages/text-input/src/InputContainer.tsx
+++ b/packages/text-input/src/InputContainer.tsx
@@ -7,7 +7,9 @@ import type { ReactElement } from 'react';
 import type { InputAdornmentProps } from './InputAdornment';
 
 export type InputContainerProps = {
+  /** Slot to start render adornment. */
   startAdornment?: ReactElement<InputAdornmentProps> | null;
+  /** Slot to end render adornment. */
   endAdornment?: ReactElement<InputAdornmentProps> | null;
 } & Omit<BoxProps, 'background' | 'position'>;
 


### PR DESCRIPTION
Fixes the table formatting and adds descriptions for the InputContainer: 
https://spark.brighte.com.au/package/text-input#inputcontainer-1

Don't think it needs a changeset since we haven't published since the InputContainer was added yesterday...