### PR TITLE
feat(combobox): expose isLoading prop

### DIFF
--- a/.changeset/short-brooms-kneel.md
+++ b/.changeset/short-brooms-kneel.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/combobox': minor
+---
+
+expose isLoading prop

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -146,3 +146,4 @@ return (
 | value          | Nullable\<Item\>                  |                                | The selected item.                                                               |
 | getOptionLabel | (option: Item) => string          | (option: Item) => option.label | Resolves option data to a string to be displayed as the label by components      |
 | getOptionValue | (option: Item) => string          | (option: Item) => option.value | Resolves option data to a string to compare options and specify value attributes |
+| isLoading      | boolean                           |                                | Is the select in a state of loading (async). Useful when manually loading items  |

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -136,14 +136,14 @@ return (
 
 ## Props
 
-| Prop           | Type                              | Default                        | Description                                                                      |
-| -------------- | --------------------------------- | ------------------------------ | -------------------------------------------------------------------------------- |
-| placeholder    | string                            |                                | The text that appears in the form control when it has no value set.              |
-| inputValue     | string                            |                                | The value of the input.                                                          |
-| items          | Item[] \| Promise\<Item[]\>       |                                | Array of items for the user to select from.                                      |
-| onChange       | (value: Nullable\<Item\>) => void |                                | Called when an item is selected.                                                 |
-| onInputChange  | (inputValue: string) => void      |                                | Called whenever the input value changes. Use to filter the items.                |
-| value          | Nullable\<Item\>                  |                                | The selected item.                                                               |
-| getOptionLabel | (option: Item) => string          | (option: Item) => option.label | Resolves option data to a string to be displayed as the label by components      |
-| getOptionValue | (option: Item) => string          | (option: Item) => option.value | Resolves option data to a string to compare options and specify value attributes |
-| isLoading      | boolean                           |                                | Is the select in a state of loading (async). Useful when manually loading items  |
+| Prop           | Type                              | Default                        | Description                                                                       |
+| -------------- | --------------------------------- | ------------------------------ | --------------------------------------------------------------------------------- |
+| getOptionLabel | (option: Item) => string          | (option: Item) => option.label | Resolves option data to a string to be displayed as the label by components.      |
+| getOptionValue | (option: Item) => string          | (option: Item) => option.value | Resolves option data to a string to compare options and specify value attributes. |
+| inputValue     | string                            |                                | The value of the input.                                                           |
+| isLoading      | boolean                           |                                | When true, shows a loading indicator in the dropdown instead of results.          |
+| items          | Item[] \| Promise\<Item[]\>       |                                | Array of items for the user to select from.                                       |
+| onChange       | (value: Nullable\<Item\>) => void |                                | Called when an item is selected.                                                  |
+| onInputChange  | (inputValue: string) => void      |                                | Called whenever the input value changes. Use to filter the items.                 |
+| placeholder    | string                            |                                | The text that appears in the form control when it has no value set.               |
+| value          | Nullable\<Item\>                  |                                | The selected item.                                                                |

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -35,6 +35,8 @@ export type ComboboxProps<Item = unknown> = {
   getOptionLabel?: GetOptionLabel<Item>;
   /** Resolves option data to a string to compare options and specify value attributes */
   getOptionValue?: GetOptionValue<Item>;
+  /** Is the select in a state of loading (async) */
+  isLoading?: boolean;
 };
 
 const isBrowser = typeof window !== 'undefined';
@@ -66,6 +68,7 @@ export const Combobox = <Item,>({
   onInputChange,
   getOptionLabel,
   getOptionValue,
+  isLoading,
   value,
 }: ComboboxProps<Item>) => {
   const [{ disabled, invalid }, { id: inputId, ...a11yProps }] =
@@ -88,7 +91,8 @@ export const Combobox = <Item,>({
       value={value}
       options={items}
       isDisabled={disabled}
-      isLoading={loading}
+      // * When using react-query or manually loading items, we need to use isLoading to determine the loading status
+      isLoading={isLoading ?? loading}
       placeholder={placeholder}
       theme={themeOverride}
       menuPortalTarget={isBrowser ? document.body : undefined}

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -14,29 +14,37 @@ type Nullable<T> = T | null;
 type Awaitable<T> = T | Promise<T>;
 
 export type ComboboxProps<Item = unknown> = {
-  /** The text that appears in the form control when it has no value set. */
-  placeholder?: string;
-  /** The value of the input. */
-  inputValue?: string;
-  /** Array of items for the user to select from. */
-  items: Awaitable<Item[]>;
-  /** Called when an item is selected. */
-  onChange?: (value: Nullable<Item>) => void;
-  /** Called whenever the input value changes. Use to filter the items. */
-  onInputChange?: (inputValue: string) => void;
-  /** The selected item. */
-  value?: Nullable<Item>;
   /**
-   * Resolves option data to a string to be displayed as the label by components
+   * Resolves option data to a string to be displayed as the label by components.
    *
    * Note: Failure to resolve to a string type can interfere with filtering and
    * screen reader support.
    */
   getOptionLabel?: GetOptionLabel<Item>;
-  /** Resolves option data to a string to compare options and specify value attributes */
+
+  /** Resolves option data to a string to compare options and specify value attributes. */
   getOptionValue?: GetOptionValue<Item>;
-  /** Is the select in a state of loading (async) */
+
+  /** The value of the input. */
+  inputValue?: string;
+
+  /** Array of items for the user to select from. */
+  items: Awaitable<Item[]>;
+
+  /** When true, shows a loading indicator in the dropdown instead of results. */
   isLoading?: boolean;
+
+  /** Called when an item is selected. */
+  onChange?: (value: Nullable<Item>) => void;
+
+  /** Called whenever the input value changes. Use to filter the items. */
+  onInputChange?: (inputValue: string) => void;
+
+  /** The text that appears in the form control when it has no value set. */
+  placeholder?: string;
+
+  /** The selected item. */
+  value?: Nullable<Item>;
 };
 
 const isBrowser = typeof window !== 'undefined';
@@ -91,7 +99,6 @@ export const Combobox = <Item,>({
       value={value}
       options={items}
       isDisabled={disabled}
-      // * When using react-query or manually loading items, we need to use isLoading to determine the loading status
       isLoading={isLoading ?? loading}
       placeholder={placeholder}
       theme={themeOverride}

--- a/packages/combobox/src/react-select-overrides.tsx
+++ b/packages/combobox/src/react-select-overrides.tsx
@@ -23,6 +23,7 @@ export const reactSelectComponentsOverride: SelectComponentsConfig<
     </components.DropdownIndicator>
   ),
   IndicatorSeparator: () => null,
+  LoadingIndicator: () => null,
   LoadingMessage: props => (
     <components.LoadingMessage {...props}>
       <Box paddingY="large">


### PR DESCRIPTION
# Description

Expose combobox `isLoading` prop from `react-select` to manually control loading status

# Checklist:

- [x] I've updated unit tests where needed
- [x] I've updated the components README.md where needed
- [ ] I've added major version bumps for my breaking changes
- [x] I've added changesets where needed
- [x] All the components I've updated are reflected in the changelog
