### PR TITLE
Tighten up spacing for Field

### DIFF
--- a/.changeset/two-islands-fold.md
+++ b/.changeset/two-islands-fold.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/field': patch
+---
+
+Tighten up spacing

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -93,14 +93,14 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
       hidden: hiddenLabel,
       visible: (
         <Box as="label" htmlFor={inputId}>
-          <Text
-            inline
-            tone={disabled ? 'disabled' : 'neutral'}
-            weight="semibold"
-          >
+          <Text tone={disabled ? 'disabled' : 'neutral'} weight="semibold">
             {label}{' '}
             {secondaryLabel && (
-              <Text inline tone={disabled ? 'disabled' : 'muted'}>
+              <Text
+                inline
+                tone={disabled ? 'disabled' : 'muted'}
+                weight="regular"
+              >
                 {secondaryLabel}
               </Text>
             )}
@@ -120,7 +120,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
     return (
       <FieldContextProvider value={fieldContext}>
         <Stack
-          gap={labelVisibility === 'hidden' ? undefined : 'small'}
+          gap={labelVisibility === 'hidden' ? undefined : 'medium'}
           ref={forwardedRef}
           {...(data ? buildDataAttributes(data) : null)}
         >


### PR DESCRIPTION
# Description

I noticed that the spacing in our field could use tightening up a little as Capsize wasn't controlling the line-height of the label.
Removing the `inline` prop from this element brought things a lot closer together so I've also bumped up the spacing of the Stack responsible for the vertical spacing to account for it.

Before (notice the extra space on the label and adornment row):
![PixelSnap 2022-05-23 at 14 40 05@2x](https://user-images.githubusercontent.com/3422401/169744657-910515c8-232b-480e-afa7-9b2027608089.png)

After:
![PixelSnap 2022-05-23 at 14 52 42@2x](https://user-images.githubusercontent.com/3422401/169745901-8ca00481-c281-4b6c-854f-03ccbf0a479c.png)

