### PR TITLE
Load fonts from Brighte subdomain

### DIFF
--- a/.changeset/pretty-cheetahs-remain.md
+++ b/.changeset/pretty-cheetahs-remain.md
@@ -1,0 +1,7 @@
+---
+'@spark-web/core': minor
+---
+
+Load fonts from Brighte subdomain
+
+Export font URLS

--- a/packages/core/src/fonts.tsx
+++ b/packages/core/src/fonts.tsx
@@ -1,30 +1,30 @@
 import { Global } from '@emotion/react';
 
-export function AesteticoStylesheet(): JSX.Element {
-  return <Global styles={fonts} />;
-}
+export const AESTETICO_REGULAR_URL =
+  'https://static-assets.prod.cloud.brighte.com.au/fonts/Aestetico-Regular.woff2';
+export const AESTETICO_SEMIBOLD_URL =
+  'https://static-assets.prod.cloud.brighte.com.au/fonts/Aestetico-SemiBold.woff2';
 
-/**
- * Note: fonts being loaded from the Brighte subdomain are currently being
- * blocked by CORS hence it's commented out here and we are using the Vercel
- * deploy preview link instead.
- */
-const fonts = `
+const styles = `
 @import "//hello.myfonts.net/count/46e60e";
+
 @font-face {
   font-family: Aestetico;
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  /* src: url(https://static-assets.prod.cloud.brighte.com.au/fonts/Aestetico-Regular.woff2) format("woff2"); */
-  src: url(https://spark-web-docs-fa4i8lp4e-brighte.vercel.app/fonts/aestetico-regular.woff2) format("woff2");
+  src: url(${AESTETICO_REGULAR_URL}) format("woff2");
 }
+
 @font-face {
   font-family: Aestetico;
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  /* src: url(https://static-assets.prod.cloud.brighte.com.au/fonts/Aestetico-SemiBold.woff2) format("woff2"); */
-  src: url(https://spark-web-docs-fa4i8lp4e-brighte.vercel.app/fonts/aestetico-semibold.woff2) format("woff2");
+  src: url(${AESTETICO_SEMIBOLD_URL}) format("woff2");
 }
 `.trim();
+
+export function AesteticoStylesheet(): JSX.Element {
+  return <Global styles={styles} />;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,8 @@
-export { AesteticoStylesheet } from './fonts';
+export {
+  AESTETICO_REGULAR_URL,
+  AESTETICO_SEMIBOLD_URL,
+  AesteticoStylesheet,
+} from './fonts';
 export { SparkProvider } from './SparkProvider';
 
 // types


### PR DESCRIPTION
# Description

Once the CORS issues are fixes, we can load fonts from the Brighte subdomain. Until then I'm leaving this PR open.