### PR TITLE
Fix the `reserve-space` prop reserving the wrong amount of space

### DIFF
--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -110,9 +110,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
       'reserve-space': (
         <Fragment>
           {hiddenLabel}
-          <Text inline aria-hidden>
-            &nbsp;
-          </Text>
+          <Text aria-hidden>&nbsp;</Text>
         </Fragment>
       ),
     };


### PR DESCRIPTION
# Description

After merging [this PR](https://github.com/brighte-labs/spark-web/pull/123), I noticed that the `reserve-space` prop was now reserving the wrong amount of space. This PR fixes that.

Before:
![PixelSnap 2022-05-23 at 16 47 05@2x](https://user-images.githubusercontent.com/3422401/169759783-67fe0e4a-fe89-4e27-a4a2-294a4be77607.png)

After:
![PixelSnap 2022-05-23 at 16 47 23@2x](https://user-images.githubusercontent.com/3422401/169759818-9496f0de-eac1-4c63-8d0c-1252117c97ce.png)

Changes are already covered by this changeset:
https://github.com/brighte-labs/spark-web/blob/main/.changeset/two-islands-fold.md
