### PR TITLE
Fix collapsing gap on Stack in Field

### DIFF
--- a/.changeset/lovely-dryers-argue.md
+++ b/.changeset/lovely-dryers-argue.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/field': patch
+---
+
+Fix collapsing gap on stack that wraps label, description, input and message

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -6,7 +6,6 @@ import { Stack } from '@spark-web/stack';
 import { Text } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import { buildDataAttributes } from '@spark-web/utils/internal';
 import type { ReactElement, ReactNode } from 'react';
 import { forwardRef, Fragment } from 'react';
 
@@ -115,22 +114,27 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
       ),
     };
 
+    const LabelWrapper =
+      labelVisibility === 'hidden'
+        ? Fragment
+        : ({ children }: { children: ReactNode }) => (
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="spaceBetween"
+              gap="large"
+            >
+              {children}
+            </Box>
+          );
+
     return (
       <FieldContextProvider value={fieldContext}>
-        <Stack
-          gap={labelVisibility === 'hidden' ? undefined : 'medium'}
-          ref={forwardedRef}
-          {...(data ? buildDataAttributes(data) : null)}
-        >
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="spaceBetween"
-            gap="large"
-          >
+        <Stack ref={forwardedRef} data={data} gap="medium">
+          <LabelWrapper>
             {labelElement[labelVisibility]}
             {adornment}
-          </Box>
+          </LabelWrapper>
 
           {description && (
             <Text tone="muted" size="small" id={descriptionId}>

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -115,18 +115,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
     };
 
     const LabelWrapper =
-      labelVisibility === 'hidden'
-        ? Fragment
-        : ({ children }: { children: ReactNode }) => (
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="spaceBetween"
-              gap="large"
-            >
-              {children}
-            </Box>
-          );
+      labelVisibility === 'hidden' ? Fragment : FieldLabelWrapper;
 
     return (
       <FieldContextProvider value={fieldContext}>
@@ -167,6 +156,18 @@ export function useFieldIds(id?: string) {
 
 // Styled components
 // ------------------------------
+function FieldLabelWrapper({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="spaceBetween"
+      gap="large"
+    >
+      {children}
+    </Box>
+  );
+}
 
 const messageToneMap = {
   critical: 'critical',


### PR DESCRIPTION
# Description

[Joss pointed out](https://brighte-au.slack.com/archives/C03C4J5AUHY/p1653353190316019) that the gap property was collapsing in certain scenarios.
This is because the gap was being set to `undefined` if the `labelVisibility` was set to "hidden". We did this because the Box that wraps the label was still appearing in the DOM, and the gap prop was causing space to be reserved for this hidden element (forgetting that the gap was needed for the description and message to be spaced properly.

In my testing, it looks like we can wrap the label with a fragment if labelVisibility is hidden, as Flexbox is smart enough to not reserve space for the `VisuallyHidden` label (I tested this in Brave (Chromium), Firefox and Safari).

## Associated Tickets

- [SPRK-92](https://brighte.atlassian.net/browse/SPRK-92)
