### PR TITLE
Remove inline from Legend

### DIFF
--- a/.changeset/forty-shoes-wave.md
+++ b/.changeset/forty-shoes-wave.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/fieldset': patch
+---
+
+Tighten up spacing in Fieldset

--- a/packages/fieldset/src/fieldset.tsx
+++ b/packages/fieldset/src/fieldset.tsx
@@ -28,7 +28,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
     <Box as="fieldset" data={data} id={id} ref={forwardedRef}>
       {legend && (
         <>
-          <Text as="legend" inline tone="neutral" weight="semibold">
+          <Text as="legend" tone="neutral" weight="semibold">
             {legend}
           </Text>
           <Gap gap={gap} />


### PR DESCRIPTION
# Description

This PR updates the Fieldset `<legend>` to have the same treatment as [our updated Field `<labels>`](https://github.com/brighte-labs/spark-web/pull/123).

Before:
![PixelSnap 2022-05-24 at 12 29 55@2x](https://user-images.githubusercontent.com/3422401/169936455-cc7d774e-7f0f-4f64-b77b-2292281d4c9c.png)

After:
![PixelSnap 2022-05-24 at 12 30 33@2x](https://user-images.githubusercontent.com/3422401/169936525-5e7f2313-ea0b-40a4-88be-842c59b7e9d3.png)
