### PR TITLE
Pass through data-attributes and a11y props to underlying input in Combobox

### DIFF
--- a/.changeset/wet-rivers-sell.md
+++ b/.changeset/wet-rivers-sell.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/combobox': patch
+---
+
+Update combobox to accept both aria attributes and data attributes

--- a/.changeset/wet-rivers-sell.md
+++ b/.changeset/wet-rivers-sell.md
@@ -1,5 +1,5 @@
 ---
-'@spark-web/combobox': patch
+'@spark-web/combobox': minor
 ---
 
 Update combobox to accept both aria attributes and data attributes

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -136,14 +136,18 @@ return (
 
 ## Props
 
-| Prop           | Type                              | Default                        | Description                                                                       |
-| -------------- | --------------------------------- | ------------------------------ | --------------------------------------------------------------------------------- |
-| getOptionLabel | (option: Item) => string          | (option: Item) => option.label | Resolves option data to a string to be displayed as the label by components.      |
-| getOptionValue | (option: Item) => string          | (option: Item) => option.value | Resolves option data to a string to compare options and specify value attributes. |
-| inputValue     | string                            |                                | The value of the input.                                                           |
-| isLoading      | boolean                           |                                | When true, shows a loading indicator in the dropdown instead of results.          |
-| items          | Item[] \| Promise\<Item[]\>       |                                | Array of items for the user to select from.                                       |
-| onChange       | (value: Nullable\<Item\>) => void |                                | Called when an item is selected.                                                  |
-| onInputChange  | (inputValue: string) => void      |                                | Called whenever the input value changes. Use to filter the items.                 |
-| placeholder    | string                            |                                | The text that appears in the form control when it has no value set.               |
-| value          | Nullable\<Item\>                  |                                | The selected item.                                                                |
+| Prop           | Type                                   | Default                        | Description                                                                       |
+| -------------- | -------------------------------------- | ------------------------------ | --------------------------------------------------------------------------------- |
+| getOptionLabel | (option: Item) => string               | (option: Item) => option.label | Resolves option data to a string to be displayed as the label by components.      |
+| getOptionValue | (option: Item) => string               | (option: Item) => option.value | Resolves option data to a string to compare options and specify value attributes. |
+| inputValue     | string                                 |                                | The value of the input.                                                           |
+| isLoading      | boolean                                |                                | When true, shows a loading indicator in the dropdown instead of results.          |
+| items          | Item[] \| Promise\<Item[]\>            |                                | Array of items for the user to select from.                                       |
+| onChange       | (value: Nullable\<Item\>) => void      |                                | Called when an item is selected.                                                  |
+| onInputChange  | (inputValue: string) => void           |                                | Called whenever the input value changes. Use to filter the items.                 |
+| placeholder    | string                                 |                                | The text that appears in the form control when it has no value set.               |
+| value          | Nullable\<Item\>                       |                                | The selected item.                                                                |
+| data?          | [DataAttributeMap][data-attribute-map] |                                | Sets data attributes on the component.                                            |
+
+[data-attribute-map]:
+  https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -18,6 +18,7 @@
     "@spark-web/text": "^1.0.5",
     "@spark-web/text-input": "^1.2.0",
     "@spark-web/theme": "^3.0.1",
+    "@spark-web/utils": "^1.1.3",
     "react-select": "^5.3.2"
   },
   "devDependencies": {

--- a/packages/combobox/src/combobox.test.tsx
+++ b/packages/combobox/src/combobox.test.tsx
@@ -1,0 +1,95 @@
+import '@testing-library/jest-dom';
+
+import type { FieldProps, Tone } from '@spark-web/field';
+import { Field } from '@spark-web/field';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type { ComboboxProps } from './combobox';
+import { Combobox } from './combobox';
+
+// Tone['critical'];
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useEffect: jest.fn(),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  cleanup();
+});
+
+const items: Item[] = [
+  { label: 'Test One', value: 'Test One' },
+  { label: 'Test Two', value: 'Test Two' },
+];
+type Item = { label: string; value: string };
+
+const defaultFieldProps = {
+  id: 'id',
+  message: 'some test message',
+  label: 'some test label',
+  tone: 'muted' as Tone,
+};
+
+describe('Combobox component', () => {
+  const renderComponent = (
+    comboProps?: ComboboxProps,
+    fieldProps?: Omit<FieldProps, 'children'>
+  ) => {
+    return render(
+      <Field
+        id={fieldProps?.id}
+        message={fieldProps?.message}
+        label={fieldProps?.label || 'default test label'}
+        tone={fieldProps?.tone}
+      >
+        <Combobox
+          items={comboProps?.items || items}
+          onChange={value => value}
+          value={'value'}
+        />
+      </Field>
+    );
+  };
+  it('should render correctly', () => {
+    const props: ComboboxProps = {
+      items,
+    };
+    renderComponent(props);
+    expect(screen.getByRole('combobox')).toBeTruthy();
+  });
+  it('should assume the ID passed in from wrapper field component', () => {
+    const props = {
+      ...defaultFieldProps,
+      id: 'some-test-id',
+    };
+    renderComponent(undefined, props);
+    expect(screen.getByRole('combobox').id).toEqual('some-test-id');
+  });
+  it('should use the field message to populate the aria-describedby attribute on the combobox input element', () => {
+    const props = {
+      ...defaultFieldProps,
+      id: 'some-test-id',
+    };
+    renderComponent(undefined, props);
+    expect(
+      screen.getByRole('combobox').getAttribute('aria-describedby')
+    ).toEqual('some-test-id--message');
+  });
+  it('should not pass through the aria-invalid attribute to the combobox input element if tone not set to critical', () => {
+    renderComponent(undefined, defaultFieldProps);
+    expect(
+      screen.getByRole('combobox').getAttribute('aria-invalid')
+    ).toBeFalsy();
+  });
+  it('should pass through the aria-invalid attribute to combobox input element correctly if tone set to critical', () => {
+    const props = {
+      ...defaultFieldProps,
+      tone: 'critical' as Tone,
+    };
+    renderComponent(undefined, props);
+    expect(screen.getByRole('combobox').getAttribute('aria-invalid')).toEqual(
+      'true'
+    );
+  });
+});

--- a/packages/combobox/src/combobox.test.tsx
+++ b/packages/combobox/src/combobox.test.tsx
@@ -47,6 +47,7 @@ describe('Combobox component', () => {
           items={comboProps?.items || items}
           onChange={value => value}
           value={'value'}
+          data={comboProps?.data}
         />
       </Field>
     );
@@ -90,6 +91,16 @@ describe('Combobox component', () => {
     renderComponent(undefined, props);
     expect(screen.getByRole('combobox').getAttribute('aria-invalid')).toEqual(
       'true'
+    );
+  });
+  it('should pass through data attributes', () => {
+    const props: ComboboxProps = {
+      items,
+      data: { testAttr: 'some attr' },
+    };
+    renderComponent(props);
+    expect(screen.getByRole('combobox').getAttribute('data-testAttr')).toEqual(
+      'some attr'
     );
   });
 });

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -90,6 +90,7 @@ export const Combobox = <Item,>({
   return (
     <ReactSelect<Item>
       {...a11yProps}
+      aria-labelledby={a11yProps['aria-describedby']}
       components={reactSelectComponentsOverride}
       inputId={inputId}
       inputValue={inputValue}

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -1,9 +1,6 @@
 import { useFieldContext } from '@spark-web/field';
-import type {
-  DataAttributeMap } from '@spark-web/utils/internal';
-import {
-  buildDataAttributes
-} from '@spark-web/utils/internal';
+import type { DataAttributeMap } from '@spark-web/utils/internal';
+import { buildDataAttributes } from '@spark-web/utils/internal';
 import { useEffect, useRef, useState } from 'react';
 import type { GetOptionLabel, GetOptionValue } from 'react-select';
 import ReactSelect from 'react-select';

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -4,7 +4,7 @@ import type { GetOptionLabel, GetOptionValue } from 'react-select';
 import ReactSelect from 'react-select';
 
 import {
-  reactSelectComponentsOverride,
+  getReactSelectComponentsOverride,
   useReactSelectStylesOverride,
   useReactSelectThemeOverride,
 } from './react-select-overrides';
@@ -84,14 +84,16 @@ export const Combobox = <Item,>({
 
   const stylesOverride = useReactSelectStylesOverride<Item>({ invalid });
   const themeOverride = useReactSelectThemeOverride();
+  const componentsOverride = getReactSelectComponentsOverride({
+    ...a11yProps,
+    // TODO: pass in data attributes as well
+  });
 
   const { items, loading } = useAwaitableItems(_items);
 
   return (
     <ReactSelect<Item>
-      {...a11yProps}
-      aria-labelledby={a11yProps['aria-describedby']}
-      components={reactSelectComponentsOverride}
+      components={componentsOverride}
       inputId={inputId}
       inputValue={inputValue}
       onChange={onChange}

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -1,4 +1,9 @@
 import { useFieldContext } from '@spark-web/field';
+import type {
+  DataAttributeMap } from '@spark-web/utils/internal';
+import {
+  buildDataAttributes
+} from '@spark-web/utils/internal';
 import { useEffect, useRef, useState } from 'react';
 import type { GetOptionLabel, GetOptionValue } from 'react-select';
 import ReactSelect from 'react-select';
@@ -45,6 +50,9 @@ export type ComboboxProps<Item = unknown> = {
 
   /** The selected item. */
   value?: Nullable<Item>;
+
+  /** Sets data attributes on the component. */
+  data?: DataAttributeMap;
 };
 
 const isBrowser = typeof window !== 'undefined';
@@ -78,6 +86,7 @@ export const Combobox = <Item,>({
   getOptionValue,
   isLoading,
   value,
+  data,
 }: ComboboxProps<Item>) => {
   const [{ disabled, invalid }, { id: inputId, ...a11yProps }] =
     useFieldContext();
@@ -86,7 +95,7 @@ export const Combobox = <Item,>({
   const themeOverride = useReactSelectThemeOverride();
   const componentsOverride = getReactSelectComponentsOverride({
     ...a11yProps,
-    // TODO: pass in data attributes as well
+    ...(data ? buildDataAttributes(data) : undefined),
   });
 
   const { items, loading } = useAwaitableItems(_items);

--- a/packages/combobox/src/react-select-overrides.tsx
+++ b/packages/combobox/src/react-select-overrides.tsx
@@ -17,6 +17,13 @@ export const reactSelectComponentsOverride: SelectComponentsConfig<
   false,
   GroupBase<any>
 > = {
+  Input: props => (
+    <components.Input
+      {...props}
+      aria-invalid={props.selectProps['aria-invalid']}
+      aria-describedby={props.selectProps['aria-labelledby']}
+    />
+  ),
   DropdownIndicator: props => (
     <components.DropdownIndicator {...props}>
       <ChevronDownIcon size="xxsmall" tone="muted" />

--- a/packages/combobox/src/react-select-overrides.tsx
+++ b/packages/combobox/src/react-select-overrides.tsx
@@ -1,5 +1,6 @@
 import { useFocusRing } from '@spark-web/a11y';
 import { Box } from '@spark-web/box';
+import type { InputPropsDerivedFromField } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
 import { Spinner } from '@spark-web/spinner';
 import { Text, useText } from '@spark-web/text';
@@ -12,18 +13,10 @@ import type {
 } from 'react-select';
 import { components } from 'react-select';
 
-export const reactSelectComponentsOverride: SelectComponentsConfig<
-  any,
-  false,
-  GroupBase<any>
-> = {
-  Input: props => (
-    <components.Input
-      {...props}
-      aria-invalid={props.selectProps['aria-invalid']}
-      aria-describedby={props.selectProps['aria-labelledby']}
-    />
-  ),
+export const getReactSelectComponentsOverride = (
+  componentProps: Omit<InputPropsDerivedFromField, 'id'>
+): SelectComponentsConfig<any, false, GroupBase<any>> => ({
+  Input: props => <components.Input {...props} {...componentProps} />,
   DropdownIndicator: props => (
     <components.DropdownIndicator {...props}>
       <ChevronDownIcon size="xxsmall" tone="muted" />
@@ -45,7 +38,7 @@ export const reactSelectComponentsOverride: SelectComponentsConfig<
       </Box>
     </components.NoOptionsMessage>
   ),
-};
+});
 
 export const useReactSelectStylesOverride = <Item,>({
   invalid,


### PR DESCRIPTION
# Description

Shout out to @lukebennett88 who did 99% of the hard yards on this PR. Basically schooled me! bahaha!

Combobox now passes through aria props from wrapper field component to the ReactSelect Input element. 
Combobox now passes through data attributes passed into the component in line with other components in the Lib

# Associated Tickets

- SPRK-83
- SPRK-84

# Checklist:

- [x] I've updated unit tests where needed
- [x] I've updated the components README.md where needed
- [x] I've added major version bumps for my breaking changes
- [x] I've added changesets where needed
- [x] All the components I've updated are reflected in the changelog
