### PR TITLE
Suppress Webpack `PackFileCacheStrategy` warnings

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -7,6 +7,12 @@ import { withSearchIndex } from './utils/with-search-index.mjs';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  webpack: config => ({
+    ...config,
+    infrastructureLogging: {
+      level: 'error',
+    },
+  }),
 };
 
 export default withPlugins(


### PR DESCRIPTION
# Description

We're currently seeing a bunch of Webpack `PackFileCacheStrategy` warnings:

![CleanShot 2022-05-29 at 15 10 19@2x](https://user-images.githubusercontent.com/3422401/170853183-67c83b8f-d195-4323-82c0-f87fbc4c262e.png)

This adds a lot of noise to the console, making it hard to find what you're looking for.

This started happening after adding [Contentlayer](https://www.contentlayer.dev/), and the warnings themselves also reference Contentlayer.

For the time being, I'm proposing we suppress these warnings as it seems to be an issue with Webpack itself:
https://github.com/vercel/next.js/discussions/30870#discussioncomment-1862620
