### PR TITLE
Check for `animationTarget` in `useSynchronizedAnimation`

### DIFF
--- a/.changeset/beige-otters-lick.md
+++ b/.changeset/beige-otters-lick.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/utils': patch
+---
+
+Check if animationTarget defined

--- a/packages/spinner/README.md
+++ b/packages/spinner/README.md
@@ -1,6 +1,6 @@
 ---
 title: Spinner
-storybookPath: feedback-overlays-spinner-—default
+storybookPath: feedback-overlays-spinner--default
 ---
 
 Spinner indicates users that their request is in progress
@@ -19,22 +19,22 @@ const tones = ['secondary', 'critical', 'positive', 'neutral'];
 return (
   <Stack align="left" gap="xxlarge">
     <Inline gap="xxlarge">
-      {tones.map((tone, index) => (
-        <Button tone={tone} prominence="low" key={`low-btn-${index}`}>
+      {tones.map(tone => (
+        <Button tone={tone} prominence="low" key={tone}>
           <Spinner />
         </Button>
       ))}
     </Inline>
     <Inline gap="xxlarge">
-      {tones.map((tone, index) => (
-        <Button tone={tone} key={`btn-${index}`}>
+      {tones.map(tone => (
+        <Button tone={tone} key={tone}>
           <Spinner />
         </Button>
       ))}
     </Inline>
     <Inline gap="xxlarge">
-      {tones.map((tone, index) => (
-        <Spinner tone={tone} key={`spinner-${index}`} />
+      {tones.map(tone => (
+        <Spinner tone={tone} key={tone} />
       ))}
     </Inline>
   </Stack>

--- a/packages/spinner/src/Spinner.test.tsx
+++ b/packages/spinner/src/Spinner.test.tsx
@@ -2,8 +2,8 @@ import '@testing-library/jest-dom';
 
 import { render } from '@testing-library/react';
 
-import type { SpinnerProps } from '.';
-import { Spinner } from '.';
+import type { SpinnerProps } from './Spinner';
+import { Spinner } from './Spinner';
 
 jest.mock('@spark-web/utils', () => {
   const original = jest.requireActual('@spark-web/utils');

--- a/packages/spinner/src/Spinner.test.tsx
+++ b/packages/spinner/src/Spinner.test.tsx
@@ -5,14 +5,6 @@ import { render } from '@testing-library/react';
 import type { SpinnerProps } from './Spinner';
 import { Spinner } from './Spinner';
 
-jest.mock('@spark-web/utils', () => {
-  const original = jest.requireActual('@spark-web/utils');
-  return {
-    ...original,
-    useSynchronizedAnimation: jest.fn(),
-  };
-});
-
 const renderComponent = (props?: SpinnerProps) => {
   return render(<Spinner data={props?.data} />);
 };

--- a/packages/utils/src/use-synchronized-animation.ts
+++ b/packages/utils/src/use-synchronized-animation.ts
@@ -7,7 +7,7 @@ let stashedTime: number | null;
 /**
  * Keeps all instances of the same animation in sync.
  * Taken from Sam Selikoff's example post:
- * @see: https://github.com/samselikoff/2022-02-24-use-synchronized-animation
+ * @see https://github.com/samselikoff/2022-02-24-use-synchronized-animation
  */
 export function useSynchronizedAnimation(animationName: string) {
   const ref = useRef(null);
@@ -24,19 +24,21 @@ export function useSynchronizedAnimation(animationName: string) {
       animation => animation.effect?.target === ref.current
     );
 
-    if (animationTarget === animations[0] && stashedTime) {
-      animationTarget.currentTime = stashedTime;
-    }
-
-    if (animationTarget && animationTarget !== animations[0]) {
-      animationTarget.currentTime = animations[0].currentTime;
-    }
-
-    return () => {
-      if (animationTarget === animations[0]) {
-        stashedTime = animationTarget.currentTime;
+    if (animationTarget) {
+      if (animationTarget === animations[0] && stashedTime) {
+        animationTarget.currentTime = stashedTime;
       }
-    };
+
+      if (animationTarget && animationTarget !== animations[0]) {
+        animationTarget.currentTime = animations[0].currentTime;
+      }
+
+      return () => {
+        if (animationTarget === animations[0]) {
+          stashedTime = animationTarget.currentTime;
+        }
+      };
+    }
   }, [animationName]);
 
   return ref;


### PR DESCRIPTION
# Description

There was a bug in the `useSynchronizedAnimation` that was picked up in a test:
![image](https://user-images.githubusercontent.com/3422401/170899320-9615b2f9-37b4-46e8-b740-c9f4fbae3a73.png)

Looks like `animationTarget` could potentially be undefined, so this PR adds a guard, as well as updates our tests and some minor docs fixes that I picked up while looking at the `Spinner`.

Note: none of the code for the `Spinner` itself has been changed (just docs and test) so it's just the `utils` that has a changelog.