### PR TITLE
feat(spinner): make spinner accessible

### DIFF
--- a/.changeset/thirty-eels-perform.md
+++ b/.changeset/thirty-eels-perform.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/spinner': patch
+---
+
+Add role 'progressbar'

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
+    "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/utils": "^1.1.3"

--- a/packages/spinner/src/Spinner.test.tsx
+++ b/packages/spinner/src/Spinner.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import type { SpinnerProps } from './Spinner';
 import { Spinner } from './Spinner';
@@ -13,7 +13,9 @@ describe('Spinner component', () => {
   it('should have spinner as svg', () => {
     const { container } = renderComponent();
     expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
+
   it('should display data props when passed down', () => {
     const data = { testAttr: 'some attr' };
     const { container } = renderComponent({ data });

--- a/packages/spinner/src/Spinner.tsx
+++ b/packages/spinner/src/Spinner.tsx
@@ -1,4 +1,5 @@
 import { css, keyframes } from '@emotion/css';
+import { VisuallyHidden } from '@spark-web/a11y';
 import { Box } from '@spark-web/box';
 import type { IconProps } from '@spark-web/icon';
 import { createIcon } from '@spark-web/icon';
@@ -29,9 +30,16 @@ export function Spinner({ tone, size = 'xxsmall', data }: SpinnerProps) {
       alignItems="center"
       justifyContent="center"
       data={data}
-      role="progressbar"
     >
-      <SpinnerIcon size={size} tone={tone} ref={strokeAnimationRef} />
+      <VisuallyHidden>
+        Image of a partial circle indicating "loading".
+      </VisuallyHidden>
+      <SpinnerIcon
+        size={size}
+        tone={tone}
+        ref={strokeAnimationRef}
+        aria-hidden="true"
+      />
     </Box>
   );
 }

--- a/packages/spinner/src/Spinner.tsx
+++ b/packages/spinner/src/Spinner.tsx
@@ -29,6 +29,7 @@ export function Spinner({ tone, size = 'xxsmall', data }: SpinnerProps) {
       alignItems="center"
       justifyContent="center"
       data={data}
+      role="progressbar"
     >
       <SpinnerIcon size={size} tone={tone} ref={strokeAnimationRef} />
     </Box>


### PR DESCRIPTION
# Description

Currently, in test we have no way to tell whether the app is in a loading state.
Make Spinner accessible so that we can wait for it to disappear.

# Associated Tickets

# Checklist:

- [x ] I've updated unit tests where needed
- [x ] I've updated the components README.md where needed
- [x ] I've added major version bumps for my breaking changes
- [x ] I've added changesets where needed
- [x ] All the components I've updated are reflected in the changelog
