### PR TITLE
Add type="button" to `IconButton`

### DIFF
--- a/.changeset/curvy-ducks-appear.md
+++ b/.changeset/curvy-ducks-appear.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/password-input': patch
+---
+
+Add type="button" to IconButton to prevent submitting form

--- a/packages/password-input/src/IconButton.tsx
+++ b/packages/password-input/src/IconButton.tsx
@@ -16,7 +16,13 @@ export const IconButton = ({
   ...rest
 }: IconButtonProps) => {
   return (
-    <Box as="button" onClick={handleClick} {...useIconButtonStyles()} {...rest}>
+    <Box
+      {...rest}
+      {...useIconButtonStyles()}
+      as="button"
+      type="button"
+      onClick={handleClick}
+    >
       {children}
     </Box>
   );


### PR DESCRIPTION
# Description

Clicking the show/hide button in the PasswordInput will submit the form as a button defaults to `type="submit"`.
Adding `type="button"` fixes this.
