### PR TITLE
Centre `HiddenWhenLoading` container inside of `Button`

### DIFF
--- a/.changeset/rich-cycles-rush.md
+++ b/.changeset/rich-cycles-rush.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/button': patch
+---
+
+Better align icons inside of buttons

--- a/packages/button/src/resolveButtonChildren.tsx
+++ b/packages/button/src/resolveButtonChildren.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { Box } from '@spark-web/box';
 import { Text } from '@spark-web/text';
 import type { ReactNode } from 'react';
 import { Children, cloneElement, isValidElement } from 'react';
@@ -74,8 +74,14 @@ function HiddenWhenLoading({
   isLoading: boolean;
 }) {
   return (
-    <span className={isLoading ? css({ opacity: 0 }) : undefined}>
+    <Box
+      as="span"
+      display="inline-flex"
+      alignItems="center"
+      justifyContent="center"
+      opacity={isLoading ? 0 : undefined}
+    >
       {children}
-    </span>
+    </Box>
   );
 }


### PR DESCRIPTION
# Description

I noticed that small icons were slightly misaligned when inside of a button. This PR fixes it!

Before:
![PixelSnap 2022-06-02 at 17 06 22@2x](https://user-images.githubusercontent.com/3422401/171572962-05d53870-5ba8-486a-86cd-43de9d833f44.png)

After:
![PixelSnap 2022-06-02 at 17 07 06@2x](https://user-images.githubusercontent.com/3422401/171573083-2f5dccf5-993b-452f-a64b-12ed94f49be2.png)
