### PR TITLE
Add spread back to Row

### DIFF
--- a/.changeset/neat-pumpkins-grab.md
+++ b/.changeset/neat-pumpkins-grab.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/row': patch
+---
+
+Update props that Row receives

--- a/.changeset/tough-spies-wink.md
+++ b/.changeset/tough-spies-wink.md
@@ -5,7 +5,6 @@
 '@spark-web/heading': major
 '@spark-web/modal-dialog': major
 '@spark-web/radio': major
-'@spark-web/row': major
 '@spark-web/text-list': major
 ---
 

--- a/packages/row/src/Row.tsx
+++ b/packages/row/src/Row.tsx
@@ -35,12 +35,13 @@ export type RowProps = {
 
 export const Row = forwardRefWithAs<'div', RowProps>(
   (
-    { align = 'left', alignY = 'stretch', children, data, dividers },
+    { align = 'left', alignY = 'stretch', children, data, dividers, ...rest },
     forwardedRef
   ) => {
     const justifyContent = alignToJustifyContent(align);
     const alignItems = alignYToAlignItems(alignY);
     const rootProps = {
+      ...rest,
       ref: forwardedRef,
       display: 'flex',
       alignItems,


### PR DESCRIPTION
# Description

Adds prop spreading back to `Row` that was removed [here](https://github.com/brighte-labs/spark-web/pull/99).
Layout primitive will need to keep the spread as they are polymorphic, so the valid props will vary depending on what the `as` prop is.

Before:
![PixelSnap 2022-06-03 at 12 59 30@2x](https://user-images.githubusercontent.com/3422401/171778061-b98b6cc8-93c5-44cd-878e-adab7436c651.png)

After:
![PixelSnap 2022-06-03 at 13 00 33@2x](https://user-images.githubusercontent.com/3422401/171778114-19a9c1d8-5fce-4986-b179-f3c97d3f4936.png)
