### PR TITLE
Add className and style back to layout primitives

### DIFF
--- a/.changeset/itchy-papayas-divide.md
+++ b/.changeset/itchy-papayas-divide.md
@@ -1,0 +1,6 @@
+---
+'@spark-web/columns': minor
+'@spark-web/row': minor
+---
+
+Add className and style back to layout primitives

--- a/packages/columns/src/Columns.tsx
+++ b/packages/columns/src/Columns.tsx
@@ -24,8 +24,6 @@ type ValidBoxProps = Omit<
   | 'flexDirection'
   | 'justifyContent'
   | 'flexWrap'
-  | 'className'
-  | 'style'
   | 'dangerouslySetInnerHTML'
 >;
 

--- a/packages/row/src/Row.tsx
+++ b/packages/row/src/Row.tsx
@@ -17,8 +17,6 @@ type ValidBoxProps = Omit<
   | 'flexDirection'
   | 'justifyContent'
   | 'flexWrap'
-  | 'className'
-  | 'style'
   | 'dangerouslySetInnerHTML'
 >;
 


### PR DESCRIPTION
# Description

We removed a bunch of instances of prop spreading in <https://github.com/brighte-labs/spark-web/pull/99>.
I'm a little unsure about removing `className` and `style` props as there are valid use cases for them at the moment (e.g. with the `Stack` component in the docs, [we set an arbitrary width using `style`](https://spark.brighte.com.au/package/text#overflow-strategy)).

Whilst it's not recommended to use these props if you can help it, sometimes they are the lesser of two evils!
