### PR TITLE
Props doc UI

### DIFF
--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -6,7 +6,6 @@ import type { TextListProps } from '@spark-web/text-list';
 import { TextList } from '@spark-web/text-list';
 import type { ReactNode } from 'react';
 import { Children, createContext, Fragment, useContext } from 'react';
-import type { ComponentDoc } from 'react-docgen-typescript';
 
 import * as sparkComponents from '../../cache/spark-components';
 import { Heading } from '../../components/content/toc-context';
@@ -24,9 +23,11 @@ interface CodeProps {
   metastring?: string;
 }
 
-export const DataContext = createContext<{ props: ComponentDoc[] } | null>(
-  null
-);
+export type DataContextType = {
+  props: Record<string, { displayName: string; props: Record<string, any> }>;
+};
+
+export const DataContext = createContext<DataContextType>(null);
 
 function Code({ children, className, demo, ...props }: CodeProps): JSX.Element {
   const trimmedChildren = children.trim();
@@ -82,9 +83,12 @@ export const mdxComponents: Record<string, ReactNode> = {
   code: Code,
   PropsTable: ({ displayName }: { displayName: string }) => {
     const data = useContext(DataContext);
-    const propsDoc = data!.props.find(comp => {
-      return comp.displayName === displayName;
-    });
+
+    if (!data?.props) {
+      return null;
+    }
+
+    const propsDoc = data.props[displayName];
     return <ComponentPropsDocTables propsDoc={propsDoc} />;
   },
   // Design System Components

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -100,7 +100,9 @@ export const mdxComponents: Record<string, ReactNode> = {
     }
 
     const propsDoc = data.props[displayName];
-    return <ComponentPropsDocTables propsDoc={propsDoc} />;
+    return (
+      <ComponentPropsDocTables propsDoc={propsDoc} displayName={displayName} />
+    );
   },
   // Design System Components
   ...sparkComponents,

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -25,7 +25,7 @@ interface CodeProps {
 
 export type DataContextType = {
   props: Record<string, { displayName: string; props: Record<string, any> }>;
-};
+} | null;
 
 export const DataContext = createContext<DataContextType>(null);
 

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -23,8 +23,19 @@ interface CodeProps {
   metastring?: string;
 }
 
+export type PropsType = {
+  name: string;
+  required: boolean;
+  type: string;
+  defaultValue: any;
+  description: string;
+};
+
 export type DataContextType = {
-  props: Record<string, { displayName: string; props: Record<string, any> }>;
+  props: Record<
+    string,
+    { displayName: string; props: Record<string, PropsType> }
+  >;
 } | null;
 
 export const DataContext = createContext<DataContextType>(null);

--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -5,10 +5,12 @@ import { TextLink } from '@spark-web/text-link';
 import type { TextListProps } from '@spark-web/text-list';
 import { TextList } from '@spark-web/text-list';
 import type { ReactNode } from 'react';
-import { Children, Fragment } from 'react';
+import { Children, createContext, Fragment, useContext } from 'react';
+import type { ComponentDoc } from 'react-docgen-typescript';
 
 import * as sparkComponents from '../../cache/spark-components';
 import { Heading } from '../../components/content/toc-context';
+import { ComponentPropsDocTables } from '../../components/mdx-components/props-doc-tables';
 import { InlineCode } from '../example-helpers';
 import { CodeBlock } from './code-block';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
@@ -21,6 +23,10 @@ interface CodeProps {
   live: true;
   metastring?: string;
 }
+
+export const DataContext = createContext<{ props: ComponentDoc[] } | null>(
+  null
+);
 
 function Code({ children, className, demo, ...props }: CodeProps): JSX.Element {
   const trimmedChildren = children.trim();
@@ -74,6 +80,13 @@ export const mdxComponents: Record<string, ReactNode> = {
   // avoid wrapping live examples in pre tag
   pre: Fragment,
   code: Code,
+  PropsTable: ({ displayName }: { displayName: string }) => {
+    const data = useContext(DataContext);
+    const propsDoc = data!.props.find(comp => {
+      return comp.displayName === displayName;
+    });
+    return <ComponentPropsDocTables propsDoc={propsDoc} />;
+  },
   // Design System Components
   ...sparkComponents,
 };

--- a/docs/components/mdx-components/mdx-content.tsx
+++ b/docs/components/mdx-components/mdx-content.tsx
@@ -1,4 +1,5 @@
 import { useLiveReload, useMDXComponent } from 'next-contentlayer/hooks';
+import type { ComponentDoc } from 'react-docgen-typescript';
 
 import { DataContext, mdxComponents } from './mdx-components';
 
@@ -7,12 +8,12 @@ export function MDXContent({
   data,
 }: {
   code: string;
-  data: Record<string, any>;
+  data: ComponentDoc[];
 }) {
   useLiveReload();
   const Component = useMDXComponent(code);
   return (
-    <DataContext.Provider value={data}>
+    <DataContext.Provider value={{ props: data }}>
       <Component components={mdxComponents} />
     </DataContext.Provider>
   );

--- a/docs/components/mdx-components/mdx-content.tsx
+++ b/docs/components/mdx-components/mdx-content.tsx
@@ -1,9 +1,19 @@
 import { useLiveReload, useMDXComponent } from 'next-contentlayer/hooks';
 
-import { mdxComponents } from './mdx-components';
+import { DataContext, mdxComponents } from './mdx-components';
 
-export function MDXContent({ code }: { code: string }) {
+export function MDXContent({
+  code,
+  data,
+}: {
+  code: string;
+  data: Record<string, any>;
+}) {
   useLiveReload();
   const Component = useMDXComponent(code);
-  return <Component components={mdxComponents} />;
+  return (
+    <DataContext.Provider value={data}>
+      <Component components={mdxComponents} />
+    </DataContext.Provider>
+  );
 }

--- a/docs/components/mdx-components/mdx-content.tsx
+++ b/docs/components/mdx-components/mdx-content.tsx
@@ -1,6 +1,6 @@
 import { useLiveReload, useMDXComponent } from 'next-contentlayer/hooks';
-import type { ComponentDoc } from 'react-docgen-typescript';
 
+import type { DataContextType } from './mdx-components';
 import { DataContext, mdxComponents } from './mdx-components';
 
 export function MDXContent({
@@ -8,12 +8,12 @@ export function MDXContent({
   data,
 }: {
   code: string;
-  data: ComponentDoc[];
+  data: DataContextType;
 }) {
   useLiveReload();
   const Component = useMDXComponent(code);
   return (
-    <DataContext.Provider value={{ props: data }}>
+    <DataContext.Provider value={data}>
       <Component components={mdxComponents} />
     </DataContext.Provider>
   );

--- a/docs/components/mdx-components/mdx-content.tsx
+++ b/docs/components/mdx-components/mdx-content.tsx
@@ -8,12 +8,12 @@ export function MDXContent({
   data,
 }: {
   code: string;
-  data: DataContextType;
+  data?: DataContextType;
 }) {
   useLiveReload();
   const Component = useMDXComponent(code);
   return (
-    <DataContext.Provider value={data}>
+    <DataContext.Provider value={data ?? null}>
       <Component components={mdxComponents} />
     </DataContext.Provider>
   );

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -49,8 +49,21 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
     })
     .map(([key, prop]) => {
       let type = prop.type.name;
-      if (type === 'enum') {
-        type = prop.type.value.map(({ value }) => value).join(' | ');
+      if (prop.type.name === 'enum') {
+        if (prop.type.raw) {
+          if (
+            prop.type.raw.includes('|') ||
+            ['boolean' /* TODO: more? */].includes(prop.type.raw)
+          ) {
+            type = prop.type.raw;
+          } else {
+            type = `${prop.type.raw}: ${prop.type.value
+              .map(({ value }) => value)
+              .join(' | ')}`;
+          }
+        } else if (prop.type.value) {
+          type = prop.type.value.map(({ value }) => value).join(' | ');
+        }
       }
       return {
         name: key,

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@spark-web/heading';
 import { Stack } from '@spark-web/stack';
-import type { ComponentDoc, PropItem, Props } from 'react-docgen-typescript';
+import type { ComponentDoc, Props } from 'react-docgen-typescript';
 
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
@@ -24,37 +24,50 @@ export const ComponentPropsDocTables = ({
 };
 
 const PropsTable = ({ propsData }: { propsData: Props }) => {
-  type PropItemKey = keyof PropItem;
-  const propItems = [
-    'name',
-    'required',
-    'type',
-    'description',
-    'defaultValue',
-    'parent',
-    'declarations',
-    'tags',
-  ] as PropItemKey[];
-
-  const propKeys = Object.keys(propsData);
+  // Sort the required props before the non-required props
+  // Then sort alphabetically
+  const props = Object.entries(propsData).sort(([, a], [, b]) => {
+    // If they have different required-ness, sort them in different buckets
+    if (a.required !== b.required) {
+      if (a.required) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+    // Alphabetically sort the props if they're in the same "required"-ness
+    // portion
+    if (a.type.name < b.type.name) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
 
   return (
     <MdxTable>
       <MdxThead>
         <MdxTr>
-          {propItems.map(item => (
-            <MdxTh key={`${item}-prop-th`}>{item}</MdxTh>
-          ))}
+          <MdxTh>Prop</MdxTh>
+          <MdxTh>Type</MdxTh>
+          <MdxTh>Default</MdxTh>
+          <MdxTh>Description</MdxTh>
         </MdxTr>
       </MdxThead>
 
-      {propKeys.map(key => (
-        <MdxTr key={`${key}-prop-tr`}>
-          {propItems.map(item => (
-            <MdxTd key={`${item}-prop-td`}>
-              {JSON.stringify(propsData[key][item])}
-            </MdxTd>
-          ))}
+      {props.map(([key, prop]) => (
+        <MdxTr key={key}>
+          <MdxTd>
+            {key}
+            {prop.required ? '' : '?'}
+          </MdxTd>
+          <MdxTd>{prop.type.name}</MdxTd>
+          <MdxTd>
+            {typeof prop.defaultValue?.value !== 'undefined'
+              ? JSON.stringify(prop.defaultValue.value)
+              : null}
+          </MdxTd>
+          <MdxTd>{prop.description}</MdxTd>
         </MdxTr>
       ))}
     </MdxTable>

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,13 +1,12 @@
 import { Heading } from '@spark-web/heading';
 import { Stack } from '@spark-web/stack';
-import type { ComponentDoc, Props } from 'react-docgen-typescript';
 
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
 export const ComponentPropsDocTables = ({
   propsDoc,
 }: {
-  propsDoc: ComponentDoc | undefined;
+  propsDoc: any | undefined;
 }) => {
   if (!propsDoc || !Object.keys(propsDoc.props).length) {
     return null;
@@ -15,59 +14,12 @@ export const ComponentPropsDocTables = ({
   return (
     <Stack key={propsDoc.displayName} gap="medium">
       <Heading level="4">{propsDoc.displayName} Props</Heading>
-      <PropsTable propsData={propsDoc.props} />
+      <PropsTable props={propsDoc.props} />
     </Stack>
   );
 };
 
-const PropsTable = ({ propsData }: { propsData: Props }) => {
-  // Sort the required props before the non-required props,
-  // Then sort alphabetically
-  const props = Object.entries(propsData)
-    .map(([key, prop]) => {
-      let type = prop.type.name;
-      if (prop.type.name === 'enum') {
-        if (prop.type.raw) {
-          if (
-            prop.type.raw.includes('|') ||
-            ['boolean' /* TODO: more? */].includes(prop.type.raw)
-          ) {
-            type = prop.type.raw;
-          } else {
-            type = `${prop.type.raw}: ${prop.type.value
-              .map(({ value }: { value: any }) => value)
-              .join(' | ')}`;
-          }
-        } else if (prop.type.value) {
-          type = prop.type.value
-            .map(({ value }: { value: any }) => value)
-            .join(' | ');
-        }
-      }
-      return {
-        name: key,
-        required: prop.required,
-        type,
-        ...(typeof prop.defaultValue?.value !== 'undefined' && {
-          defaultValue: prop.defaultValue.value,
-        }),
-        description: prop.description,
-      };
-    })
-    .sort((a, b) => {
-      // If they have different required-ness, sort them in different buckets
-      if (a.required !== b.required) {
-        if (a.required) {
-          return -1;
-        } else {
-          return 1;
-        }
-      }
-      // Alphabetically sort the props if they're in the same required-ness
-      // bucket
-      return a.name.localeCompare(b.name);
-    });
-
+const PropsTable = ({ props }: { props: any }) => {
   if (!props.length) {
     return null;
   }
@@ -83,7 +35,7 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
         </MdxTr>
       </MdxThead>
 
-      {props.map(prop => (
+      {props.map((prop: any) => (
         <MdxTr key={prop.name}>
           <MdxTd>
             {prop.name}

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -30,23 +30,6 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
   // Sort the required props before the non-required props,
   // Then sort alphabetically
   const props = Object.entries(propsData)
-    .sort(([, a], [, b]) => {
-      // If they have different required-ness, sort them in different buckets
-      if (a.required !== b.required) {
-        if (a.required) {
-          return -1;
-        } else {
-          return 1;
-        }
-      }
-      // Alphabetically sort the props if they're in the same required-ness
-      // bucket
-      if (a.type.name < b.type.name) {
-        return 1;
-      } else {
-        return -1;
-      }
-    })
     .map(([key, prop]) => {
       let type = prop.type.name;
       if (prop.type.name === 'enum') {
@@ -76,6 +59,19 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
         }),
         description: prop.description,
       };
+    })
+    .sort((a, b) => {
+      // If they have different required-ness, sort them in different buckets
+      if (a.required !== b.required) {
+        if (a.required) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+      // Alphabetically sort the props if they're in the same required-ness
+      // bucket
+      return a.name.localeCompare(b.name);
     });
 
   if (!props.length) {

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -12,6 +12,9 @@ export const ComponentPropsDocTables = ({
   return (
     <>
       {componentPropsDoc.map(PropsDoc => {
+        if (!Object.keys(PropsDoc.props).length) {
+          return null;
+        }
         return (
           <Stack key={PropsDoc.displayName} gap="medium">
             <Heading level="2">{PropsDoc.displayName} Props</Heading>

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -58,11 +58,13 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
             type = prop.type.raw;
           } else {
             type = `${prop.type.raw}: ${prop.type.value
-              .map(({ value }) => value)
+              .map(({ value }: { value: any }) => value)
               .join(' | ')}`;
           }
         } else if (prop.type.value) {
-          type = prop.type.value.map(({ value }) => value).join(' | ');
+          type = prop.type.value
+            .map(({ value }: { value: any }) => value)
+            .join(' | ');
         }
       }
       return {

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -27,25 +27,45 @@ export const ComponentPropsDocTables = ({
 };
 
 const PropsTable = ({ propsData }: { propsData: Props }) => {
-  // Sort the required props before the non-required props
+  // Sort the required props before the non-required props,
   // Then sort alphabetically
-  const props = Object.entries(propsData).sort(([, a], [, b]) => {
-    // If they have different required-ness, sort them in different buckets
-    if (a.required !== b.required) {
-      if (a.required) {
-        return -1;
-      } else {
-        return 1;
+  const props = Object.entries(propsData)
+    .sort(([, a], [, b]) => {
+      // If they have different required-ness, sort them in different buckets
+      if (a.required !== b.required) {
+        if (a.required) {
+          return -1;
+        } else {
+          return 1;
+        }
       }
-    }
-    // Alphabetically sort the props if they're in the same "required"-ness
-    // portion
-    if (a.type.name < b.type.name) {
-      return 1;
-    } else {
-      return -1;
-    }
-  });
+      // Alphabetically sort the props if they're in the same required-ness
+      // bucket
+      if (a.type.name < b.type.name) {
+        return 1;
+      } else {
+        return -1;
+      }
+    })
+    .map(([key, prop]) => {
+      let type = prop.type.name;
+      if (type === 'enum') {
+        type = prop.type.value.map(({ value }) => value).join(' | ');
+      }
+      return {
+        name: key,
+        required: prop.required,
+        type,
+        ...(typeof prop.defaultValue?.value !== 'undefined' && {
+          defaultValue: prop.defaultValue.value,
+        }),
+        description: prop.description,
+      };
+    });
+
+  if (!props.length) {
+    return null;
+  }
 
   return (
     <MdxTable>
@@ -58,18 +78,14 @@ const PropsTable = ({ propsData }: { propsData: Props }) => {
         </MdxTr>
       </MdxThead>
 
-      {props.map(([key, prop]) => (
-        <MdxTr key={key}>
+      {props.map(prop => (
+        <MdxTr key={prop.name}>
           <MdxTd>
-            {key}
+            {prop.name}
             {prop.required ? '' : '?'}
           </MdxTd>
-          <MdxTd>{prop.type.name}</MdxTd>
-          <MdxTd>
-            {typeof prop.defaultValue?.value !== 'undefined'
-              ? JSON.stringify(prop.defaultValue.value)
-              : null}
-          </MdxTd>
+          <MdxTd>{prop.type}</MdxTd>
+          <MdxTd>{JSON.stringify(prop.defaultValue)}</MdxTd>
           <MdxTd>{prop.description}</MdxTd>
         </MdxTr>
       ))}

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,14 +1,21 @@
 import { Heading } from '@spark-web/heading';
 import { Stack } from '@spark-web/stack';
 
+import type { PropsType } from './mdx-components';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
+
+export type FormattedPropsType = {
+  [key: string]: PropsType;
+};
 
 export const ComponentPropsDocTables = ({
   propsDoc,
 }: {
-  propsDoc: any | undefined;
+  propsDoc:
+    | { displayName: string; props: Record<string, PropsType> }
+    | undefined;
 }) => {
-  if (!propsDoc || !Object.keys(propsDoc.props).length) {
+  if (!propsDoc || !Object.keys(propsDoc?.props).length) {
     return null;
   }
   return (
@@ -19,8 +26,8 @@ export const ComponentPropsDocTables = ({
   );
 };
 
-const PropsTable = ({ props }: { props: any }) => {
-  if (!props.length) {
+const PropsTable = ({ props }: { props: Record<string, PropsType> }) => {
+  if (!Object.keys(props).length) {
     return null;
   }
 
@@ -35,17 +42,20 @@ const PropsTable = ({ props }: { props: any }) => {
         </MdxTr>
       </MdxThead>
 
-      {props.map((prop: any) => (
-        <MdxTr key={prop.name}>
-          <MdxTd>
-            {prop.name}
-            {prop.required ? '' : '?'}
-          </MdxTd>
-          <MdxTd>{prop.type}</MdxTd>
-          <MdxTd>{JSON.stringify(prop.defaultValue)}</MdxTd>
-          <MdxTd>{prop.description}</MdxTd>
-        </MdxTr>
-      ))}
+      {Object.keys(props).map((key: string) => {
+        const prop = props[key];
+        return (
+          <MdxTr key={prop.name}>
+            <MdxTd>
+              {prop.name}
+              {prop.required ? '' : '?'}
+            </MdxTd>
+            <MdxTd>{prop.type}</MdxTd>
+            <MdxTd>{JSON.stringify(prop.defaultValue)}</MdxTd>
+            <MdxTd>{prop.description}</MdxTd>
+          </MdxTr>
+        );
+      })}
     </MdxTable>
   );
 };

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,0 +1,62 @@
+import { Heading } from '@spark-web/heading';
+import { Stack } from '@spark-web/stack';
+import type { ComponentDoc, PropItem, Props } from 'react-docgen-typescript';
+
+import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
+
+export const ComponentPropsDocTables = ({
+  componentPropsDoc,
+}: {
+  componentPropsDoc: ComponentDoc[];
+}) => {
+  return (
+    <>
+      {componentPropsDoc.map(PropsDoc => {
+        return (
+          <Stack key={PropsDoc.displayName} gap="medium">
+            <Heading level="2">{PropsDoc.displayName} Props</Heading>
+            <PropsTable propsData={PropsDoc.props} />
+          </Stack>
+        );
+      })}
+    </>
+  );
+};
+
+const PropsTable = ({ propsData }: { propsData: Props }) => {
+  type PropItemKey = keyof PropItem;
+  const propItems = [
+    'name',
+    'required',
+    'type',
+    'description',
+    'defaultValue',
+    'parent',
+    'declarations',
+    'tags',
+  ] as PropItemKey[];
+
+  const propKeys = Object.keys(propsData);
+
+  return (
+    <MdxTable>
+      <MdxThead>
+        <MdxTr>
+          {propItems.map(item => (
+            <MdxTh key={`${item}-prop-th`}>{item}</MdxTh>
+          ))}
+        </MdxTr>
+      </MdxThead>
+
+      {propKeys.map(key => (
+        <MdxTr key={`${key}-prop-tr`}>
+          {propItems.map(item => (
+            <MdxTd key={`${item}-prop-td`}>
+              {JSON.stringify(propsData[key][item])}
+            </MdxTd>
+          ))}
+        </MdxTr>
+      ))}
+    </MdxTable>
+  );
+};

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -10,17 +10,17 @@ export type FormattedPropsType = {
 
 export const ComponentPropsDocTables = ({
   propsDoc,
+  displayName,
 }: {
-  propsDoc:
-    | { displayName: string; props: Record<string, PropsType> }
-    | undefined;
+  propsDoc: { props: Record<string, PropsType> } | undefined;
+  displayName: string;
 }) => {
   if (!propsDoc || !Object.keys(propsDoc?.props).length) {
     return null;
   }
   return (
-    <Stack key={propsDoc.displayName} gap="medium">
-      <Heading level="4">{propsDoc.displayName} Props</Heading>
+    <Stack key={displayName} gap="medium">
+      <Heading level="3">{displayName}</Heading>
       <PropsTable props={propsDoc.props} />
     </Stack>
   );

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -5,24 +5,18 @@ import type { ComponentDoc, Props } from 'react-docgen-typescript';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
 export const ComponentPropsDocTables = ({
-  componentPropsDoc,
+  propsDoc,
 }: {
-  componentPropsDoc: ComponentDoc[];
+  propsDoc: ComponentDoc | undefined;
 }) => {
+  if (!propsDoc || !Object.keys(propsDoc.props).length) {
+    return null;
+  }
   return (
-    <>
-      {componentPropsDoc.map(PropsDoc => {
-        if (!Object.keys(PropsDoc.props).length) {
-          return null;
-        }
-        return (
-          <Stack key={PropsDoc.displayName} gap="medium">
-            <Heading level="2">{PropsDoc.displayName} Props</Heading>
-            <PropsTable propsData={PropsDoc.props} />
-          </Stack>
-        );
-      })}
-    </>
+    <Stack key={propsDoc.displayName} gap="medium">
+      <Heading level="4">{propsDoc.displayName} Props</Heading>
+      <PropsTable propsData={propsDoc.props} />
+    </Stack>
   );
 };
 

--- a/docs/pages/package/[slug].tsx
+++ b/docs/pages/package/[slug].tsx
@@ -20,6 +20,7 @@ import { GITHUB_URL } from '../../components/constants';
 import { DocsContent } from '../../components/content';
 import { InlineCode } from '../../components/example-helpers';
 import { MDXContent } from '../../components/mdx-components/mdx-content';
+import { ComponentPropsDocTables } from '../../components/mdx-components/props-doc-tables';
 import { StorybookIcon } from '../../components/vectors/fill';
 import type { HeadingData } from '../../utils/generate-toc';
 
@@ -37,6 +38,7 @@ export const getStaticProps: GetStaticProps<{
   storybookPath: string | null;
   title: string;
   toc: HeadingData[];
+  propsDoc: any;
 }> = async ({ params }) => {
   const pkg = allPackages.find(p => p.slug === params!.slug);
   if (!pkg) {
@@ -52,6 +54,7 @@ export const getStaticProps: GetStaticProps<{
       storybookPath: pkg.storybookPath ?? null,
       title: pkg.title,
       toc: pkg.toc,
+      propsDoc: pkg.props,
     },
   };
 };
@@ -62,6 +65,7 @@ export default function Packages({
   storybookPath,
   title,
   toc,
+  propsDoc,
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element {
   const packageSlug = packageName.replace('@spark-web/', '');
 
@@ -76,6 +80,11 @@ export default function Packages({
         />
         <Divider />
         <MDXContent code={code} />
+        <Divider />
+        <Divider />
+        <Divider />
+        <Divider />
+        <ComponentPropsDocTables componentPropsDoc={propsDoc} />
       </Stack>
     </DocsContent>
   );

--- a/docs/pages/package/[slug].tsx
+++ b/docs/pages/package/[slug].tsx
@@ -14,6 +14,7 @@ import type {
   InferGetStaticPropsType,
 } from 'next';
 import { createElement } from 'react';
+import type { ComponentDoc } from 'react-docgen-typescript';
 
 import { allPackages } from '../../.contentlayer/generated';
 import { GITHUB_URL } from '../../components/constants';
@@ -46,6 +47,8 @@ export const getStaticProps: GetStaticProps<{
     };
   }
 
+  const propsDoc = formatPropsData(pkg.props);
+
   return {
     props: {
       code: pkg.body.code,
@@ -53,9 +56,64 @@ export const getStaticProps: GetStaticProps<{
       storybookPath: pkg.storybookPath ?? null,
       title: pkg.title,
       toc: pkg.toc,
-      propsDoc: pkg.props,
+      propsDoc,
     },
   };
+};
+
+const formatPropsData = (originalPropsData: ComponentDoc[]) => {
+  // Sort the required props before the non-required props,
+  // Then sort alphabetically
+  return originalPropsData.map(propsData => {
+    const props = Object.entries(propsData.props)
+      .map(([key, prop]) => {
+        let type = prop.type.name;
+        if (prop.type.name === 'enum') {
+          if (prop.type.raw) {
+            if (
+              prop.type.raw.includes('|') ||
+              ['boolean' /* TODO: more? */].includes(prop.type.raw)
+            ) {
+              type = prop.type.raw;
+            } else {
+              type = `${prop.type.raw}: ${prop.type.value
+                .map(({ value }: { value: any }) => value)
+                .join(' | ')}`;
+            }
+          } else if (prop.type.value) {
+            type = prop.type.value
+              .map(({ value }: { value: any }) => value)
+              .join(' | ');
+          }
+        }
+        return {
+          name: key,
+          required: prop.required,
+          type,
+          ...(typeof prop.defaultValue?.value !== 'undefined' && {
+            defaultValue: prop.defaultValue.value,
+          }),
+          description: prop.description,
+        };
+      })
+      .sort((a, b) => {
+        // If they have different required-ness, sort them in different buckets
+        if (a.required !== b.required) {
+          if (a.required) {
+            return -1;
+          } else {
+            return 1;
+          }
+        }
+        // Alphabetically sort the props if they're in the same required-ness
+        // bucket
+        return a.name.localeCompare(b.name);
+      });
+    return {
+      ...originalPropsData,
+      props,
+    };
+  });
 };
 
 export default function Packages({

--- a/docs/pages/package/[slug].tsx
+++ b/docs/pages/package/[slug].tsx
@@ -20,6 +20,7 @@ import { allPackages } from '../../.contentlayer/generated';
 import { GITHUB_URL } from '../../components/constants';
 import { DocsContent } from '../../components/content';
 import { InlineCode } from '../../components/example-helpers';
+import type { DataContextType } from '../../components/mdx-components/mdx-components';
 import { MDXContent } from '../../components/mdx-components/mdx-content';
 import { StorybookIcon } from '../../components/vectors/fill';
 import type { HeadingData } from '../../utils/generate-toc';
@@ -59,7 +60,9 @@ export const getStaticProps: GetStaticProps<{
   };
 };
 
-const formatPropsData = (originalPropsData: ComponentDoc[]) =>
+const formatPropsData = (
+  originalPropsData: ComponentDoc[]
+): Record<string, DataContextType> =>
   originalPropsData
     .map(propsData => ({
       displayName: propsData.displayName,

--- a/docs/pages/package/[slug].tsx
+++ b/docs/pages/package/[slug].tsx
@@ -20,7 +20,6 @@ import { GITHUB_URL } from '../../components/constants';
 import { DocsContent } from '../../components/content';
 import { InlineCode } from '../../components/example-helpers';
 import { MDXContent } from '../../components/mdx-components/mdx-content';
-import { ComponentPropsDocTables } from '../../components/mdx-components/props-doc-tables';
 import { StorybookIcon } from '../../components/vectors/fill';
 import type { HeadingData } from '../../utils/generate-toc';
 
@@ -79,12 +78,7 @@ export default function Packages({
           packageSlug={packageSlug}
         />
         <Divider />
-        <MDXContent code={code} />
-        <Divider />
-        <Divider />
-        <Divider />
-        <Divider />
-        <ComponentPropsDocTables componentPropsDoc={propsDoc} />
+        <MDXContent code={code} data={{ props: propsDoc }} />
       </Stack>
     </DocsContent>
   );

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -198,23 +198,7 @@ with the exception of `href` vs `onClick` props.
 
 ## Props
 
-| Prop              | Type                                                                                     | Default   | Description                                                                                                                               |
-| ----------------- | ---------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| aria-controls?    | string                                                                                   |           | Identifies the element (or elements) whose contents or presence are controlled by the current element. Only applicable for `Button`.      |
-| aria-describedby? | string                                                                                   |           | Identifies the element (or elements) that describes the object. Only applicable for `Button`.                                             |
-| aria-expanded?    | string                                                                                   |           | Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. Only applicable for `Button`. |
-| children          | string \| React.ReactElement\<IconProps>                                                 |           | Children element to be rendered inside the button.                                                                                        |
-| data?             | [DataAttributeMap][data-attribute-map]                                                   |           | Allows setting of data attributes on the button.                                                                                          |
-| disabled?         | boolean                                                                                  |           | When true, prevents `onClick` from firing. Only applicable for `Button`.                                                                  |
-| href              | string                                                                                   |           | Specifies the url the button should redirect to upon being clicked. Only applicable for `ButtonLink`.                                     |
-| id?               | string                                                                                   |           | Unique identifier for the button.                                                                                                         |
-| label?            | string                                                                                   |           | Implicit label for buttons only required for icon-only buttons for accessibility reasons.                                                 |
-| loading?          | boolean                                                                                  |           | When true, the button will display a loading spinner.                                                                                     |
-| onClick?          | Function                                                                                 |           | Function to be fired following a click event of the button. Only applicable for `Button`.                                                 |
-| prominence?       | 'high' \| 'low'                                                                          | 'high'    | Sets the visual prominence of the button.                                                                                                 |
-| size?             | 'medium' \| 'large'                                                                      | 'medium'  | Sets the size of the button.                                                                                                              |
-| tone?             | 'primary' \| 'secondary' \| 'neutral' \| 'positive' \| 'caution' \| 'critical' \| 'info' | 'primary' | Sets the tone of the button.                                                                                                              |
-| type?             | 'button' \| 'submit' \| 'reset'                                                          | 'button'  | Sets the button type. Only applicable for `Button`.                                                                                       |
+<PropsTable displayName="Button"/>
 
 [data-attribute-map]:
   https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1


### PR DESCRIPTION
# Implement `PropsTable` in MDX to render docgen props 
 - format and sort props data into the shape which is faster in retrieving 
 - wrap `PropsTable` inside MDX which offers full flexibility of readme layout
 - utilise react context to avoid prop drilling 
