### PR TITLE
Make Field a peer dep to avoid context bug

### DIFF
--- a/.changeset/polite-walls-brake.md
+++ b/.changeset/polite-walls-brake.md
@@ -1,0 +1,12 @@
+---
+'@spark-web/combobox': patch
+'@spark-web/currency-input': patch
+'@spark-web/dropzone': patch
+'@spark-web/float-input': patch
+'@spark-web/password-input': patch
+'@spark-web/select': patch
+'@spark-web/text-area': patch
+'@spark-web/text-input': patch
+---
+
+Make Field a peer dep to avoid context bug

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -12,7 +12,6 @@
     "@emotion/css": "^11.9.0",
     "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/spinner": "^1.0.3",
     "@spark-web/text": "^1.0.5",
@@ -22,10 +21,12 @@
     "react-select": "^5.3.2"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/currency-input/package.json
+++ b/packages/currency-input/package.json
@@ -10,15 +10,16 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/float-input": "^1.0.2",
     "@spark-web/text": "^1.0.5",
     "@spark-web/text-input": "^1.2.1"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -14,7 +14,6 @@
     "@spark-web/alert": "^1.0.6",
     "@spark-web/box": "^1.0.5",
     "@spark-web/button": "^1.1.2",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/stack": "^1.0.5",
     "@spark-web/text": "^1.0.5",
@@ -24,10 +23,12 @@
     "react-dropzone": "^12.0.4"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/float-input/package.json
+++ b/packages/float-input/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/inline": "^1.0.5",
     "@spark-web/stack": "^1.0.5",
@@ -19,11 +18,13 @@
     "numeral": "^2.0.6"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/numeral": "^2.0.2",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/password-input/package.json
+++ b/packages/password-input/package.json
@@ -13,7 +13,6 @@
     "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
     "@spark-web/button": "^1.1.2",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/float-input": "^1.0.2",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/text": "^1.0.5",
@@ -21,10 +20,12 @@
     "@spark-web/theme": "^3.0.1"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -12,7 +12,6 @@
     "@emotion/css": "^11.9.0",
     "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/icon": "^1.1.3",
     "@spark-web/text": "^1.0.5",
     "@spark-web/text-input": "^1.2.1",
@@ -20,10 +19,12 @@
     "@spark-web/utils": "^1.1.3"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -11,17 +11,18 @@
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
     "@spark-web/box": "^1.0.5",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/text": "^1.0.5",
     "@spark-web/text-input": "^1.2.1",
     "@spark-web/theme": "^3.0.1",
     "@spark-web/utils": "^1.1.3"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -12,16 +12,17 @@
     "@emotion/css": "^11.9.0",
     "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
-    "@spark-web/field": "^3.0.0",
     "@spark-web/text": "^1.0.5",
     "@spark-web/theme": "^3.0.1",
     "@spark-web/utils": "^1.1.3"
   },
   "devDependencies": {
+    "@spark-web/field": "^3.0.0",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },
   "peerDependencies": {
+    "@spark-web/field": "^3.0.0",
     "react": ">=17.0.2"
   },
   "engines": {


### PR DESCRIPTION
# Description

Some of our users were getting a bug when they tried to use an input that was wrapped in the Field component.

![image](https://user-images.githubusercontent.com/3422401/173505295-091416dc-6047-4146-adfe-208a1efb643e.png)

This was because the inputs had a dependency on `@spark-web/field`, and the version of Field that the inputs were using was different to the version they had installed themselves.

Moving the dependency for Field on these packages into peer-dependencies should fix this.
