### PR TITLE
Add aria-label to IconButton

### DIFF
--- a/.changeset/ninety-cows-call.md
+++ b/.changeset/ninety-cows-call.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/password-input': patch
+---
+
+Add aria-label to IconButton

--- a/packages/password-input/src/IconButton.tsx
+++ b/packages/password-input/src/IconButton.tsx
@@ -5,9 +5,10 @@ import type { ButtonHTMLAttributes, ReactElement } from 'react';
 import { useIconButtonStyles } from './useIconButtonStyles';
 
 type IconButtonProps = {
-  handleClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
-  children: ReactElement<IconProps>;
+  'aria-label': string;
   'aria-pressed'?: boolean;
+  children: ReactElement<IconProps>;
+  handleClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
 };
 
 export const IconButton = ({

--- a/packages/password-input/src/PasswordInput.tsx
+++ b/packages/password-input/src/PasswordInput.tsx
@@ -33,7 +33,11 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         type={showPassword ? 'text' : 'password'}
       >
         <InputAdornment placement="end">
-          <IconButton handleClick={handleClick} aria-pressed={showPassword}>
+          <IconButton
+            aria-label={`${showPassword ? 'Hide' : 'Show'} password`}
+            aria-pressed={showPassword}
+            handleClick={handleClick}
+          >
             <Icon tone={disabled ? 'disabled' : 'neutral'} />
           </IconButton>
         </InputAdornment>


### PR DESCRIPTION
# Description

The IconButton only has an icon inside it, so there was no way for screen readers to know what the button did.
This PR adds an aria-label to fix it!
