### PR TITLE
Add role switch and change from aria-pressed to aria-checked

### DIFF
--- a/.changeset/breezy-shirts-live.md
+++ b/.changeset/breezy-shirts-live.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/password-input': patch
+---
+
+Add role switch and change from aria-pressed to aria-checked

--- a/packages/password-input/src/IconButton.tsx
+++ b/packages/password-input/src/IconButton.tsx
@@ -4,27 +4,18 @@ import type { ButtonHTMLAttributes, ReactElement } from 'react';
 
 import { useIconButtonStyles } from './useIconButtonStyles';
 
-type IconButtonProps = {
-  'aria-label': string;
-  'aria-pressed'?: boolean;
+type NativeButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'onClick'
+>;
+
+type IconButtonProps = NativeButtonProps & {
+  onClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
   children: ReactElement<IconProps>;
-  handleClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
 };
 
-export const IconButton = ({
-  handleClick,
-  children,
-  ...rest
-}: IconButtonProps) => {
+export const IconButton = (props: IconButtonProps) => {
   return (
-    <Box
-      {...rest}
-      {...useIconButtonStyles()}
-      as="button"
-      type="button"
-      onClick={handleClick}
-    >
-      {children}
-    </Box>
+    <Box {...props} {...useIconButtonStyles()} as="button" type="button" />
   );
 };

--- a/packages/password-input/src/PasswordInput.tsx
+++ b/packages/password-input/src/PasswordInput.tsx
@@ -34,9 +34,10 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
       >
         <InputAdornment placement="end">
           <IconButton
+            aria-checked={showPassword}
             aria-label={`${showPassword ? 'Hide' : 'Show'} password`}
-            aria-pressed={showPassword}
-            handleClick={handleClick}
+            onClick={handleClick}
+            role="switch"
           >
             <Icon tone={disabled ? 'disabled' : 'neutral'} />
           </IconButton>


### PR DESCRIPTION
# Description

After reading this article and doing some manual testing with [VoiceOver](https://incl.ca/show-hide-password-accessibility-and-password-hints-tutorial/) there was some some room for improvement with our show/hide password button.

I've added a `role` of `switch` to the button to indicate it toggles between an "on" and "off" state, and changed aria-pressed to aria-checked (as `aria-pressed` and `role="switch"` are incompatible).
