### PR TITLE
Create unstyled BaseButton and focus button on click to address Safari bug

### DIFF
--- a/.changeset/fuzzy-years-hug.md
+++ b/.changeset/fuzzy-years-hug.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/button': minor
+---
+
+Create BaseButton and focus button on click to address Safari bug

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,6 +1,3 @@
-import { Heading } from '@spark-web/heading';
-import { Stack } from '@spark-web/stack';
-
 import type { PropsType } from './mdx-components';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
@@ -18,12 +15,7 @@ export const ComponentPropsDocTables = ({
   if (!propsDoc || !Object.keys(propsDoc?.props).length) {
     return null;
   }
-  return (
-    <Stack key={displayName} gap="medium">
-      <Heading level="3">{displayName}</Heading>
-      <PropsTable props={propsDoc.props} />
-    </Stack>
-  );
+  return <PropsTable key={displayName} props={propsDoc.props} />;
 };
 
 const PropsTable = ({ props }: { props: Record<string, PropsType> }) => {

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -196,9 +196,17 @@ with the exception of `href` vs `onClick` props.
 </Text>
 ```
 
-## Props
+## BaseButton
 
-<PropsTable displayName="Button"/>
+Unstyled button primitive that:
 
-[data-attribute-map]:
-  https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1
+- Forwards the button ref
+- Provides a default type of `button` (so it doesn't accidently submit forms if
+  left off)
+- Prevents `onClick` from firing when disabled without disabling the button
+- Forces focus of the underlying button when clicked (to address a bug in
+  Safari)
+
+## Button Props
+
+<PropsTable displayName="Button" />

--- a/packages/button/src/BaseButton.tsx
+++ b/packages/button/src/BaseButton.tsx
@@ -1,0 +1,67 @@
+import type { BoxProps } from '@spark-web/box';
+import { Box } from '@spark-web/box';
+import { useComposedRefs } from '@spark-web/utils';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { forwardRef, useCallback, useRef } from 'react';
+
+import type { NativeButtonProps } from './types';
+
+export type BaseButtonProps = NativeButtonProps & Partial<BoxProps>;
+
+export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
+  (
+    { onClick: onClickProp, disabled = false, type = 'button', ...rest },
+    forwardedRef
+  ) => {
+    const internalRef = useRef<HTMLButtonElement>(null);
+    const composedRef = useComposedRefs(internalRef, forwardedRef);
+    /**
+     * In Safari buttons are not focused automatically by the browser once
+     * pressed, the default behaviour is to focus the nearest focusable ancestor.
+     * To fix this we need to manually focus the button element after the user
+     * presses the element.
+     */
+    const onClick = useCallback(
+      (event: ReactMouseEvent<HTMLButtonElement>) => {
+        internalRef.current?.focus();
+        const preventableClickHandler = getPreventableClickHandler(
+          onClickProp,
+          disabled
+        );
+        preventableClickHandler(event);
+      },
+      [disabled, onClickProp]
+    );
+
+    return (
+      <Box
+        as="button"
+        {...rest}
+        onClick={onClick}
+        ref={composedRef}
+        type={type}
+      />
+    );
+  }
+);
+
+BaseButton.displayName = 'BaseButton';
+
+/**
+ * handle "disabled" behaviour w/o disabling buttons
+ * @see https://axesslab.com/disabled-buttons-suck/
+ */
+export function getPreventableClickHandler(
+  onClick: BaseButtonProps['onClick'],
+  disabled: boolean
+) {
+  return function handleClick(
+    event: ReactMouseEvent<HTMLButtonElement, MouseEvent>
+  ) {
+    if (disabled) {
+      event.preventDefault();
+    } else {
+      onClick?.(event);
+    }
+  };
+}

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -2,10 +2,9 @@ import { VisuallyHidden } from '@spark-web/a11y';
 import { Box } from '@spark-web/box';
 import type { IconProps } from '@spark-web/icon';
 import { Spinner } from '@spark-web/spinner';
-import { buildDataAttributes } from '@spark-web/utils/internal';
-import type { MouseEvent as ReactMouseEvent } from 'react';
 import { forwardRef } from 'react';
 
+import { BaseButton } from './BaseButton';
 import { resolveButtonChildren } from './resolveButtonChildren';
 import type { CommonButtonProps, NativeButtonProps } from './types';
 import { useButtonStyles } from './useButtonStyles';
@@ -52,17 +51,17 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       'aria-describedby': ariaDescribedBy,
       'aria-expanded': ariaExpanded,
       data,
-      disabled = false,
+      disabled,
       id,
       loading = false,
       onClick,
       prominence = 'high',
       size = 'medium',
       tone = 'primary',
-      type = 'button',
+      type,
       ...props
     },
-    ref
+    forwardedRef
   ) => {
     const iconOnly = Boolean(props.label);
     const buttonStyleProps = useButtonStyles({
@@ -77,26 +76,20 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const variant = variants[prominence][tone];
 
-    /**
-     * handle "disabled" behaviour w/o disabling buttons
-     * @see https://axesslab.com/disabled-buttons-suck/
-     */
-    const handleClick = getPreventableClickHandler(onClick, isDisabled);
-
     return (
-      <Box
+      <BaseButton
+        {...buttonStyleProps}
         aria-controls={ariaControls}
         aria-describedby={ariaDescribedBy}
         aria-disabled={isDisabled}
         aria-expanded={ariaExpanded}
         aria-label={props.label}
-        as="button"
+        data={data}
+        disabled={isDisabled}
         id={id}
-        onClick={handleClick}
-        ref={ref}
+        onClick={onClick}
+        ref={forwardedRef}
         type={type}
-        {...buttonStyleProps}
-        {...(data ? buildDataAttributes(data) : undefined)}
       >
         {resolveButtonChildren({
           ...props,
@@ -106,31 +99,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           tone,
         })}
         {isLoading && <Loading tone={variant?.textTone} />}
-      </Box>
+      </BaseButton>
     );
   }
 );
 Button.displayName = 'Button';
-
-/**
- * Prevent click events when the component is "disabled".
- * Note: we don't want to actually disable a button element for several reasons.
- * One being because that would prohibit the use of tooltips.
- */
-export function getPreventableClickHandler(
-  onClick: NativeButtonProps['onClick'],
-  disabled: boolean
-) {
-  return function handleClick(
-    event: ReactMouseEvent<HTMLButtonElement, MouseEvent>
-  ) {
-    if (disabled) {
-      event.preventDefault();
-    } else {
-      onClick?.(event);
-    }
-  };
-}
 
 function Loading({ tone }: { tone?: IconProps['tone'] }) {
   return (

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -1,7 +1,9 @@
+export { BaseButton } from './BaseButton';
 export { Button } from './Button';
 export { ButtonLink } from './ButtonLink';
 
 // types
 
+export type { BaseButtonProps } from './BaseButton';
 export type { ButtonProps } from './Button';
 export type { ButtonLinkProps } from './ButtonLink';


### PR DESCRIPTION
# Description

Inspired by [this PR](https://github.com/steelthreads/agds-next/pull/428) adds a new `BaseButton` component which is an un-styled button that will manually focus the underlying `button` after the user presses it.

The `preventableClickHandler` logic is also move the this component which we then export so other components can potentially use it.
