### PR TITLE
Enable text truncation when input value is too long

### DIFF
--- a/.changeset/shaggy-knives-rescue.md
+++ b/.changeset/shaggy-knives-rescue.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/text-input': patch
+---
+
+Enable text truncation when input value is too long

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -3,7 +3,7 @@ import { useFocusRing } from '@spark-web/a11y';
 import { Box } from '@spark-web/box';
 import type { FieldState } from '@spark-web/field';
 import { useFieldContext } from '@spark-web/field';
-import { useText } from '@spark-web/text';
+import { useOverflowStrategy, useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { InputHTMLAttributes } from 'react';
@@ -100,6 +100,7 @@ export type UseInputProps = FieldState;
 
 export const useInput = ({ disabled }: UseInputProps) => {
   const theme = useTheme();
+  const overflowStyles = useOverflowStrategy('truncate');
   const focusRingStyles = useFocusRing({ always: true });
   const textStyles = useText({
     baseline: false,
@@ -113,6 +114,7 @@ export const useInput = ({ disabled }: UseInputProps) => {
   return {
     ...typographyStyles,
     ...responsiveStyles,
+    ...overflowStyles,
     ':focus': { outline: 'none' },
     ':enabled': {
       ':focus + [data-focus-indicator]': {


### PR DESCRIPTION
# Description

Noticed we're not doing anything about text overflow in our inputs. This PR adds text truncation if the text would otherwise overflow its bounding box.

Before:
![image](https://user-images.githubusercontent.com/3422401/173504364-eb462e36-1848-4525-8a70-d5953337f998.png)

After:
![image](https://user-images.githubusercontent.com/3422401/173504393-11518237-64fa-46c6-9caa-14d471bb0d11.png)
