### PR TITLE
Update input styles

### DIFF
--- a/.changeset/cuddly-cooks-train.md
+++ b/.changeset/cuddly-cooks-train.md
@@ -1,0 +1,7 @@
+---
+'@spark-web/combobox': patch
+'@spark-web/select': patch
+'@spark-web/text-area': patch
+---
+
+Refactor to work with updated useInputStyles

--- a/.changeset/nice-dogs-sit.md
+++ b/.changeset/nice-dogs-sit.md
@@ -1,0 +1,6 @@
+---
+'@spark-web/text-input': major
+---
+
+Rename useInput to useInputStyles which now returns a tuple (boxProps and CSS
+object) and adds box shadow

--- a/.changeset/wicked-trees-smoke.md
+++ b/.changeset/wicked-trees-smoke.md
@@ -1,0 +1,6 @@
+---
+'@spark-web/select': patch
+'@spark-web/text-area': patch
+---
+
+Remove unused dependencies

--- a/packages/combobox/src/react-select-overrides.tsx
+++ b/packages/combobox/src/react-select-overrides.tsx
@@ -79,6 +79,7 @@ export const useReactSelectStylesOverride = <Item,>({
             borderColor: theme.color.foreground.critical,
           }
         : {}),
+      boxShadow: theme.shadow.small,
     }),
 
     dropdownIndicator: (provided, state) => ({

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@spark-web/field": "^3.0.0",
+    "@spark-web/utils": "^1.1.4",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -10,13 +10,9 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
-    "@spark-web/a11y": "^1.0.5",
     "@spark-web/box": "^1.0.5",
     "@spark-web/icon": "^1.1.3",
-    "@spark-web/text": "^1.0.5",
-    "@spark-web/text-input": "^1.2.1",
-    "@spark-web/theme": "^3.0.1",
-    "@spark-web/utils": "^1.1.3"
+    "@spark-web/text-input": "^1.2.1"
   },
   "devDependencies": {
     "@spark-web/field": "^3.0.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -12,7 +12,8 @@
     "@emotion/css": "^11.9.0",
     "@spark-web/box": "^1.0.5",
     "@spark-web/icon": "^1.1.3",
-    "@spark-web/text-input": "^1.2.1"
+    "@spark-web/text-input": "^1.2.1",
+    "@spark-web/theme": "^3.0.1"
   },
   "devDependencies": {
     "@spark-web/field": "^3.0.0",

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -3,7 +3,9 @@ import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
+import type { UseInputStylesProps } from '@spark-web/text-input';
 import { InputContainer, useInputStyles } from '@spark-web/text-input';
+import { useTheme } from '@spark-web/theme';
 import type { SelectHTMLAttributes } from 'react';
 import { forwardRef, useCallback } from 'react';
 
@@ -40,7 +42,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     forwardedRef
   ) => {
     const [{ disabled, invalid }, a11yProps] = useFieldContext();
-    const [boxProps, inputStyles] = useInputStyles({
+    const [boxProps, inputStyles] = useSelectStyles({
       disabled,
       invalid,
     });
@@ -112,3 +114,18 @@ const Indicator = () => {
     </Box>
   );
 };
+
+function useSelectStyles(props: UseInputStylesProps) {
+  const [boxProps, inputStyles] = useInputStyles(props);
+  const theme = useTheme();
+  return [
+    boxProps,
+    {
+      ...inputStyles,
+      // Prevent text going underneath the chevron icon
+      paddingRight:
+        theme.sizing.xxsmall + // size of chevron icon
+        theme.spacing.medium * 2, // paddingX value
+    },
+  ] as const;
+}

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -1,11 +1,9 @@
 import { css } from '@emotion/css';
+import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
-import type { UseInputProps } from '@spark-web/text-input';
-import { InputContainer, useInput } from '@spark-web/text-input';
-import { useTheme } from '@spark-web/theme';
-import type { DataAttributeMap } from '@spark-web/utils/internal';
+import { InputContainer, useInputStyles } from '@spark-web/text-input';
 import type { SelectHTMLAttributes } from 'react';
 import { forwardRef, useCallback } from 'react';
 
@@ -20,11 +18,11 @@ export type OptionsOrGroups = Array<Option | Group>;
 export type SelectProps = Pick<
   SelectHTMLAttributes<HTMLSelectElement>,
   'defaultValue' | 'name' | 'onBlur' | 'onChange' | 'required' | 'value'
-> & {
-  data?: DataAttributeMap;
-  options: OptionsOrGroups;
-  placeholder?: string;
-};
+> &
+  Pick<BoxProps, 'data'> & {
+    options: OptionsOrGroups;
+    placeholder?: string;
+  };
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   (
@@ -42,7 +40,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     forwardedRef
   ) => {
     const [{ disabled, invalid }, a11yProps] = useFieldContext();
-    const styles = useSelectStyles({ disabled, invalid });
+    const [boxProps, inputStyles] = useInputStyles({
+      disabled,
+      invalid,
+    });
 
     const mapOptions = useCallback(
       (opt: Option) => (
@@ -55,21 +56,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <InputContainer>
+        <Indicator />
         <Box
-          position="absolute"
-          top={0}
-          bottom={0}
-          right={0}
-          display="flex"
-          alignItems="center"
-          padding="medium"
-          className={css({ pointerEvents: 'none' })}
-        >
-          <ChevronDownIcon size="xxsmall" tone="placeholder" />
-        </Box>
-        <Box
+          {...boxProps}
           {...a11yProps}
           as="select"
+          className={css(inputStyles)}
           data={data}
           defaultValue={defaultValue ?? placeholder ? '' : undefined}
           disabled={disabled}
@@ -79,14 +71,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           ref={forwardedRef}
           required={required}
           value={value}
-          // Styles
-          background={disabled ? 'inputDisabled' : 'input'}
-          border={invalid ? 'critical' : 'field'}
-          borderRadius="small"
-          paddingX="medium"
-          height="medium"
           width="full"
-          className={css(styles)}
         >
           {placeholder && (
             <option value="" disabled>
@@ -111,24 +96,19 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 
 Select.displayName = 'Select';
 
-function useSelectStyles({ disabled, invalid }: UseInputProps) {
-  const theme = useTheme();
-  const inputStyles = useInput({
-    disabled,
-    invalid,
-  });
-  return {
-    ...inputStyles,
-    overflow: 'hidden', // fix for Safari to prevent unwanted scrolling of parent container to occur
-    textOverflow: 'ellipsis',
-
-    // Prevent text going underneath the chevron icon
-    paddingRight:
-      theme.sizing.xxsmall + // size of chevron icon
-      theme.spacing.medium * 2, // paddingX value
-
-    ':invalid': {
-      color: theme.color.foreground.muted,
-    },
-  };
-}
+const Indicator = () => {
+  return (
+    <Box
+      position="absolute"
+      top={0}
+      bottom={0}
+      right={0}
+      display="flex"
+      alignItems="center"
+      padding="medium"
+      className={css({ pointerEvents: 'none' })}
+    >
+      <ChevronDownIcon size="xxsmall" tone="placeholder" />
+    </Box>
+  );
+};

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -1,30 +1,41 @@
 import { css } from '@emotion/css';
-import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
 import type { UseInputStylesProps } from '@spark-web/text-input';
 import { InputContainer, useInputStyles } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
+import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { SelectHTMLAttributes } from 'react';
 import { forwardRef, useCallback } from 'react';
 
-type Option = {
+export type Option = {
+  /** Whether or not the option is disabled. */
   disabled?: boolean;
+  /** Label for the option. */
   label: string;
+  /** Value of the option. */
   value: string | number;
 };
-type Group = { options: Array<Option>; label: string };
+export type Group = {
+  /** List of options for the group. */
+  options: Array<Option>;
+  /** Label for the group. */
+  label: string;
+};
 export type OptionsOrGroups = Array<Option | Group>;
-
-export type SelectProps = Pick<
+export type NativeSelectProps = Pick<
   SelectHTMLAttributes<HTMLSelectElement>,
   'defaultValue' | 'name' | 'onBlur' | 'onChange' | 'required' | 'value'
-> &
-  Pick<BoxProps, 'data'> & {
-    options: OptionsOrGroups;
-    placeholder?: string;
-  };
+>;
+export type SelectProps = NativeSelectProps & {
+  /** Allows setting of data attributes on the underlying element. */
+  data?: DataAttributeMap;
+  /** The values that can be selected by the input. */
+  options: OptionsOrGroups;
+  /** Placeholder text for when the input does not have an initial value. */
+  placeholder?: string;
+};
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   (

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -11,10 +11,8 @@
     "@babel/runtime": "^7.18.0",
     "@emotion/css": "^11.9.0",
     "@spark-web/box": "^1.0.5",
-    "@spark-web/text": "^1.0.5",
     "@spark-web/text-input": "^1.2.1",
-    "@spark-web/theme": "^3.0.1",
-    "@spark-web/utils": "^1.1.3"
+    "@spark-web/theme": "^3.0.1"
   },
   "devDependencies": {
     "@spark-web/field": "^3.0.0",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@spark-web/field": "^3.0.0",
+    "@spark-web/utils": "^1.1.4",
     "@types/react": "^17.0.12",
     "react": "^17.0.2"
   },

--- a/packages/text-area/src/text-area.tsx
+++ b/packages/text-area/src/text-area.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/css';
-import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { InputContainer } from '@spark-web/text-input';
+import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { TextareaHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
 import { useTextAreaStyles } from './use-text-area';
 
-export type TextAreaProps = Pick<
+export type NativeTextAreaProps = Pick<
   TextareaHTMLAttributes<HTMLTextAreaElement>,
   | 'defaultValue'
   | 'name'
@@ -17,8 +17,12 @@ export type TextAreaProps = Pick<
   | 'placeholder'
   | 'required'
   | 'value'
-> &
-  Pick<BoxProps, 'data'>;
+>;
+
+export type TextAreaProps = NativeTextAreaProps & {
+  /** Allows setting of data attributes on the underlying element. */
+  data?: DataAttributeMap;
+};
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (

--- a/packages/text-area/src/text-area.tsx
+++ b/packages/text-area/src/text-area.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
+import type { BoxProps } from '@spark-web/box';
 import { Box } from '@spark-web/box';
 import { useFieldContext } from '@spark-web/field';
 import { InputContainer } from '@spark-web/text-input';
-import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { TextareaHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
@@ -17,9 +17,8 @@ export type TextAreaProps = Pick<
   | 'placeholder'
   | 'required'
   | 'value'
-> & {
-  data?: DataAttributeMap;
-};
+> &
+  Pick<BoxProps, 'data'>;
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
@@ -36,35 +35,26 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     forwardedRef
   ) => {
     const [{ disabled, invalid }, a11yProps] = useFieldContext();
-    const consumerProps = {
-      value,
-      defaultValue,
-      disabled,
-      name,
-      onBlur,
-      onChange,
-      placeholder,
-      required,
-    };
-    const textAreaStyles = useTextAreaStyles({ disabled, invalid });
+    const [boxProps, textAreaStyles] = useTextAreaStyles({ disabled, invalid });
 
     return (
       <InputContainer>
         <Box
-          {...consumerProps}
+          {...boxProps}
           {...a11yProps}
           as="textarea"
-          data={data}
-          ref={forwardedRef}
-          rows={3}
-          // Styles
-          background={disabled ? 'inputDisabled' : 'input'}
-          border={invalid ? 'critical' : 'field'}
-          borderRadius="small"
-          paddingX="medium"
-          height="medium"
-          width="full"
           className={css(textAreaStyles)}
+          data={data}
+          defaultValue={defaultValue}
+          disabled={disabled}
+          name={name}
+          onBlur={onBlur}
+          onChange={onChange}
+          placeholder={placeholder}
+          ref={forwardedRef}
+          required={required}
+          rows={3}
+          value={value}
         />
       </InputContainer>
     );

--- a/packages/text-area/src/use-text-area.ts
+++ b/packages/text-area/src/use-text-area.ts
@@ -1,27 +1,24 @@
-import type { UseInputProps } from '@spark-web/text-input';
-import { useInput } from '@spark-web/text-input';
+import type { UseInputStylesProps } from '@spark-web/text-input';
+import { useInputStyles } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
 
-export function useTextAreaStyles({ disabled, invalid }: UseInputProps) {
+export function useTextAreaStyles({ disabled, invalid }: UseInputStylesProps) {
   const theme = useTheme();
-  const inputStyles = useInput({
+  const [boxProps, inputStyles] = useInputStyles({
     disabled,
     invalid,
   });
 
-  return {
-    ...inputStyles,
-
-    // Text inputs have a fixed height, so we need to override it back to `auto`
-    height: 'auto',
-    minHeight: theme.sizing.medium,
-
-    paddingTop: theme.spacing.small,
-    paddingBottom: theme.spacing.small,
-    resize: 'vertical',
-
-    ':invalid': {
-      color: theme.color.foreground.muted,
+  return [
+    boxProps,
+    {
+      ...inputStyles,
+      // Text inputs have a fixed height, so we need to override it back to `auto`
+      height: 'auto',
+      minHeight: theme.sizing.medium,
+      paddingTop: theme.spacing.small,
+      paddingBottom: theme.spacing.small,
+      resize: 'vertical',
     },
-  } as const;
+  ] as const;
 }

--- a/packages/text-area/src/use-text-area.ts
+++ b/packages/text-area/src/use-text-area.ts
@@ -2,12 +2,9 @@ import type { UseInputStylesProps } from '@spark-web/text-input';
 import { useInputStyles } from '@spark-web/text-input';
 import { useTheme } from '@spark-web/theme';
 
-export function useTextAreaStyles({ disabled, invalid }: UseInputStylesProps) {
+export function useTextAreaStyles(props: UseInputStylesProps) {
   const theme = useTheme();
-  const [boxProps, inputStyles] = useInputStyles({
-    disabled,
-    invalid,
-  });
+  const [boxProps, inputStyles] = useInputStyles(props);
 
   return [
     boxProps,

--- a/packages/text-input/src/index.ts
+++ b/packages/text-input/src/index.ts
@@ -1,9 +1,9 @@
 export { InputAdornment } from './InputAdornment';
 export { InputContainer } from './InputContainer';
-export { TextInput, useInput } from './TextInput';
+export { TextInput, useInputStyles } from './TextInput';
 
 // types
 
 export type { AdornmentChild } from './childrenToAdornments';
 export type { InputContainerProps } from './InputContainer';
-export type { TextInputProps, UseInputProps } from './TextInput';
+export type { TextInputProps, UseInputStylesProps } from './TextInput';


### PR DESCRIPTION
# Description

This PR adds a box shadow to our field inputs, and refactors the `useInput` hook (now renamed to `useInputStyles`) to return a tuple so we can prevent some duplication.

The first item returned from the array is an object containing props that should be spread onto the underlying `Box` element that our inputs are created with, and the second object is a CSS object that should be passed to Emotion's `css` function.

## Associated Tickets

- [SPRK-27](https://brighte.atlassian.net/browse/SPRK-27)
