### PR TITLE
Simplify MDX Table component to enable better props table styling

### DIFF
--- a/docs/components/mdx-components/mdx-components.tsx
+++ b/docs/components/mdx-components/mdx-components.tsx
@@ -12,6 +12,7 @@ import { Heading } from '../../components/content/toc-context';
 import { ComponentPropsDocTables } from '../../components/mdx-components/props-doc-tables';
 import { InlineCode } from '../example-helpers';
 import { CodeBlock } from './code-block';
+import type { MdxTdProps } from './mdx-table';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
 interface CodeProps {
@@ -39,6 +40,8 @@ export type DataContextType = {
 } | null;
 
 export const DataContext = createContext<DataContextType>(null);
+
+export { InlineCode };
 
 function Code({ children, className, demo, ...props }: CodeProps): JSX.Element {
   const trimmedChildren = children.trim();
@@ -88,7 +91,11 @@ export const mdxComponents: Record<string, ReactNode> = {
   thead: MdxThead,
   tr: MdxTr,
   th: MdxTh,
-  td: MdxTd,
+  td: ({ children, ...props }: MdxTdProps) => (
+    <MdxTd {...props}>
+      <Text>{children}</Text>
+    </MdxTd>
+  ),
   // avoid wrapping live examples in pre tag
   pre: Fragment,
   code: Code,

--- a/docs/components/mdx-components/mdx-table.tsx
+++ b/docs/components/mdx-components/mdx-table.tsx
@@ -25,17 +25,12 @@ export function MdxTable({
         as="table"
         className={css({
           width: '100%',
+          tableLayout: 'fixed',
           overflow: 'auto',
           borderCollapse: 'collapse',
         })}
         {...rest}
       >
-        <colgroup>
-          <col style={{ width: '20%' }} />
-          <col style={{ width: '30%' }} />
-          <col style={{ width: '10%' }} />
-          <col style={{ width: '40%' }} />
-        </colgroup>
         {children}
       </Box>
     </Box>
@@ -105,12 +100,11 @@ export function MdxTh({
   );
 }
 
-export function MdxTd({
-  children,
-  ...rest
-}: {
+export type MdxTdProps = {
   children: ReactNode;
-}): JSX.Element {
+};
+
+export function MdxTd({ children, ...rest }: MdxTdProps): JSX.Element {
   const theme = useTheme();
   return (
     <Box
@@ -121,7 +115,7 @@ export function MdxTd({
       })}
       {...rest}
     >
-      <Text>{children}</Text>
+      {typeof children === 'string' ? <Text>{children}</Text> : children}
     </Box>
   );
 }

--- a/docs/components/mdx-components/props-doc-tables.tsx
+++ b/docs/components/mdx-components/props-doc-tables.tsx
@@ -1,4 +1,8 @@
+import { Stack } from '@spark-web/stack';
+import { Text } from '@spark-web/text';
+
 import type { PropsType } from './mdx-components';
+import { InlineCode } from './mdx-components';
 import { MdxTable, MdxTd, MdxTh, MdxThead, MdxTr } from './mdx-table';
 
 export type FormattedPropsType = {
@@ -25,11 +29,15 @@ const PropsTable = ({ props }: { props: Record<string, PropsType> }) => {
 
   return (
     <MdxTable>
+      <colgroup>
+        <col style={{ width: '20%' }} />
+        <col style={{ width: '30%' }} />
+        <col style={{ width: '50%' }} />
+      </colgroup>
       <MdxThead>
         <MdxTr>
           <MdxTh>Prop</MdxTh>
           <MdxTh>Type</MdxTh>
-          <MdxTh>Default</MdxTh>
           <MdxTh>Description</MdxTh>
         </MdxTr>
       </MdxThead>
@@ -39,12 +47,27 @@ const PropsTable = ({ props }: { props: Record<string, PropsType> }) => {
         return (
           <MdxTr key={prop.name}>
             <MdxTd>
-              {prop.name}
-              {prop.required ? '' : '?'}
+              <Text as="p" overflowStrategy="breakword">
+                {prop.name}
+                {prop.required ? '' : '?'}
+              </Text>
             </MdxTd>
-            <MdxTd>{prop.type}</MdxTd>
-            <MdxTd>{JSON.stringify(prop.defaultValue)}</MdxTd>
-            <MdxTd>{prop.description}</MdxTd>
+            <MdxTd>
+              <Text as="p" overflowStrategy="breakword">
+                {prop.type}
+              </Text>
+            </MdxTd>
+            <MdxTd>
+              <Stack gap="xlarge">
+                <Text as="p">{prop.description}</Text>
+                {typeof prop.defaultValue !== 'undefined' ? (
+                  <Text as="p">
+                    <strong>Default</strong>:{' '}
+                    <InlineCode>{JSON.stringify(prop.defaultValue)}</InlineCode>
+                  </Text>
+                ) : null}
+              </Stack>
+            </MdxTd>
           </MdxTr>
         );
       })}


### PR DESCRIPTION
# Description

Simplify MDX Table component to enable better props table styling

- Before: https://spark-web-docs-jvuenn6dg-brighte.vercel.app/package/button#button-props
- After: https://spark-web-docs-ihpkr0vb2-brighte.vercel.app/package/button#button-props