### PR TITLE
Allow `Emoji` and `VisuallyHidden` component to accept data attributes

### DIFF
--- a/.changeset/twelve-apricots-grin.md
+++ b/.changeset/twelve-apricots-grin.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/a11y': minor
+---
+
+Allow VisuallyHidden and Emoji components to accept data attributes

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -23,14 +23,7 @@ hidden from assistive technology.
 </Inline>
 ```
 
-### Props
-
-| Prop   | Type   | Default | Description                                                                 |
-| ------ | ------ | ------- | --------------------------------------------------------------------------- |
-| label? | string |         | Label used to describe the symbol that will be announced to screen readers. |
-| symbol | string |         | Emoji symbol.                                                               |
-
-## Visually hidden
+## VisuallyHidden
 
 Content which should be visually hidden, but remain accessible to assistive
 technologies such as screen readers, can be implemented using the
@@ -52,8 +45,22 @@ conveyed to non-visual users.
 
 ### Props
 
-| Prop     | Type            | Default | Description                                           |
-| -------- | --------------- | ------- | ----------------------------------------------------- |
-| children | React.ReactNode |         | Children elements to be hidden within this component. |
+### Emoji Props
+
+| Prop   | Type                                   | Default | Description                                                                 |
+| ------ | -------------------------------------- | ------- | --------------------------------------------------------------------------- |
+| data?  | [DataAttributeMap][data-attribute-map] |         | Sets data attributes on the component.                                      |
+| label? | string                                 |         | Label used to describe the symbol that will be announced to screen readers. |
+| symbol | string                                 |         | Emoji symbol.                                                               |
+
+### VisuallyHidden Props
+
+| Prop     | Type                                   | Default | Description                                           |
+| -------- | -------------------------------------- | ------- | ----------------------------------------------------- |
+| data?    | [DataAttributeMap][data-attribute-map] |         | Sets data attributes on the component.                |
+| children | React.ReactNode                        |         | Children elements to be hidden within this component. |
 
 Additional props are passed to the `span` element and are not listed.
+
+[data-attribute-map]:
+  https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1

--- a/packages/a11y/src/Emoji.tsx
+++ b/packages/a11y/src/Emoji.tsx
@@ -1,12 +1,22 @@
+import type { DataAttributeMap } from '@spark-web/utils/internal';
+import { buildDataAttributes } from '@spark-web/utils/internal';
+
 export type EmojiProps = {
+  /** Map of data attributes. */
+  data?: DataAttributeMap;
   /** Label used to describe the symbol that will be announced to screen readers. */
   label?: string;
   /** Emoji symbol. */
   symbol: string;
 };
 
-export const Emoji = ({ label, symbol }: EmojiProps) => (
-  <span aria-hidden={label ? undefined : true} aria-label={label} role="img">
+export const Emoji = ({ data, label, symbol }: EmojiProps) => (
+  <span
+    aria-hidden={label ? undefined : true}
+    aria-label={label}
+    role="img"
+    {...(data ? buildDataAttributes(data) : undefined)}
+  >
     {symbol}
   </span>
 );

--- a/packages/a11y/src/VisuallyHidden.tsx
+++ b/packages/a11y/src/VisuallyHidden.tsx
@@ -1,9 +1,14 @@
 import { css } from '@emotion/css';
+import type { DataAttributeMap } from '@spark-web/utils/internal';
+import { buildDataAttributes } from '@spark-web/utils/internal';
 import { forwardRefWithAs } from '@spark-web/utils/ts';
 import type { ReactNode } from 'react';
 
 export type VisuallyHiddenProps = {
+  /** Children element to be rendered inside the component. */
   children?: ReactNode;
+  /** Map of data attributes. */
+  data?: DataAttributeMap;
 };
 
 /**
@@ -11,8 +16,15 @@ export type VisuallyHiddenProps = {
  * @see https://a11yproject.com/posts/how-to-hide-content/
  */
 export const VisuallyHidden = forwardRefWithAs<'span', VisuallyHiddenProps>(
-  ({ as: Tag = 'span', ...props }, ref) => {
-    return <Tag ref={ref} className={css(visuallyHiddenStyles)} {...props} />;
+  ({ as: Tag = 'span', data, ...consumerProps }, forwardedRef) => {
+    return (
+      <Tag
+        {...consumerProps}
+        {...(data ? buildDataAttributes(data) : undefined)}
+        ref={forwardedRef}
+        className={css(visuallyHiddenStyles)}
+      />
+    );
   }
 );
 


### PR DESCRIPTION
This PR adds the `data` prop to `VisuallyHidden` and `Emoji` components for passing along data-attributes to the underlying components.