### PR TITLE
Show pointer when hovering over non-disabled label

### DIFF
--- a/.changeset/pink-weeks-hear.md
+++ b/.changeset/pink-weeks-hear.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/control-label': patch
+---
+
+Show pointer when hovering over non-disabled label

--- a/packages/control-label/src/control-label.tsx
+++ b/packages/control-label/src/control-label.tsx
@@ -21,10 +21,12 @@ export function ControlLabel({
   return (
     <Box
       as="label"
-      alignItems="start"
-      display="inline-flex"
-      gap={size}
       htmlFor={htmlFor}
+      // Styles
+      cursor={disabled ? 'default' : 'pointer'}
+      display="inline-flex"
+      alignItems="start"
+      gap={size}
       userSelect="none"
     >
       {control}


### PR DESCRIPTION
# Description

This is not strictly standard behaviour, but users have been taught that the pointer cursor means that the element below it is interactive.

I spoke with @jordangeizer about this a while back and we decided to adopt this slightly controversial UX.
