### PR TITLE
Add RadioCard

### DIFF
--- a/.changeset/serious-ants-hide.md
+++ b/.changeset/serious-ants-hide.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/radio': patch
+---
+
+Refactor RadioPrimitive styles

--- a/.changeset/strong-paws-tan.md
+++ b/.changeset/strong-paws-tan.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/radio': minor
+---
+
+Add RadioCard component

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -12,14 +12,14 @@ In order to toggle between options, all Radio components should have a matching
 `name` prop (unless you are using them inside of a `RadioGroup`).
 
 ```jsx live
-<Fieldset legend="Favourite Shrek character" gap="large">
-  <Radio name="character" value="Shrek">
+<Fieldset legend="Shrek Characters" gap="large">
+  <Radio name="character_radio" value="Shrek" defaultChecked>
     Shrek
   </Radio>
-  <Radio name="character" value="Fiona">
+  <Radio name="character_radio" value="Fiona">
     Fiona
   </Radio>
-  <Radio name="character" value="Donkey">
+  <Radio name="character_radio" value="Donkey">
     Donkey
   </Radio>
 </Fieldset>
@@ -30,7 +30,7 @@ In order to toggle between options, all Radio components should have a matching
 Radio buttons are available in two sizes: `small` and `medium`.
 
 ```jsx live
-<Stack gap="large">
+<Stack gap="large" dividers>
   <Fieldset legend="Radio variations (small)" gap="large">
     <Radio size="small" checked={false}>
       Unchecked
@@ -45,8 +45,7 @@ Radio buttons are available in two sizes: `small` and `medium`.
       Checked + disabled
     </Radio>
   </Fieldset>
-  <Divider />
-  <Fieldset legend="Radio variations (medium)" gap="large">
+  <Fieldset legend="Radio variations (small)" gap="large">
     <Radio size="medium" checked={false}>
       Unchecked
     </Radio>
@@ -80,8 +79,8 @@ All `Radio` children _must_ be provided with a `value`.
 const [selected, setSelected] = React.useState('Shrek');
 
 return (
-  <Fieldset legend="Favourite Shrek character" gap="medium">
-    <RadioGroup value={selected} onChange={setSelected}>
+  <Fieldset legend="Shrek Characters" gap="large">
+    <RadioGroup value={selected} onChange={setSelected} gap="large">
       <Radio value="Shrek">Shrek</Radio>
       <Radio value="Fiona">Fiona</Radio>
       <Radio value="Donkey">Donkey</Radio>
@@ -120,7 +119,7 @@ const statuses = {
 };
 
 return (
-  <Fieldset legend="Radio variations" gap="medium">
+  <Fieldset legend="Message and Tone" gap="large">
     <RadioGroup
       message={statuses[selected]?.message}
       tone={statuses[selected]?.tone}
@@ -131,6 +130,94 @@ return (
       <Radio value="positive">Positive</Radio>
       <Radio value="neutral">Neutral</Radio>
     </RadioGroup>
+  </Fieldset>
+);
+```
+
+## RadioCard
+
+A RadioCard is an alternative to Radio. Use RadioCard where a user needs to make
+one selection out of several choices, and where each option requires some
+detailed information.
+
+### Controlled
+
+```jsx live
+const terms = [
+  { label: '6 months', description: '$426.08/fortnight' },
+  { label: '12 months', description: '$214.54/fortnight' },
+  { label: '24 months', description: '$108.77/fortnight' },
+  { label: '36 months', description: '73.52/fortnight' },
+  { label: '48 months', description: '55.89/fortnight' },
+];
+
+const [selected, setSelected] = React.useState(terms[0].label);
+
+return (
+  <Stack gap="large">
+    <Fieldset legend="Select a repayment term" gap="large">
+      <RadioGroup value={selected} onChange={setSelected}>
+        {terms.map(({ label, description }) => (
+          <RadioCard key={label} value={label} description={description}>
+            {label}
+          </RadioCard>
+        ))}
+      </RadioGroup>
+    </Fieldset>
+    {selected && (
+      <Text>
+        You have selected <Strong>{selected}</Strong>
+      </Text>
+    )}
+  </Stack>
+);
+```
+
+### Uncontrolled
+
+```jsx live
+<Fieldset legend="Select a repayment term" gap="large">
+  <RadioCard
+    description="$426.08/fortnight"
+    name="repayment_terms"
+    defaultChecked
+  >
+    6 months
+  </RadioCard>
+  <RadioCard description="$214.54/fortnight" name="repayment_terms">
+    12 months
+  </RadioCard>
+  <RadioCard description="$108.77/fortnight" name="repayment_terms">
+    24 months
+  </RadioCard>
+  <RadioCard description="73.52/fortnight" name="repayment_terms">
+    36 months
+  </RadioCard>
+  <RadioCard description="55.89/fortnight" name="repayment_terms">
+    48 months
+  </RadioCard>
+</Fieldset>
+```
+
+### Without description
+
+RadioCards without a description have a lower prominence label.
+
+```jsx live
+const [selected, setSelected] = React.useState('Shrek');
+
+return (
+  <Fieldset legend="Shrek Characters" gap="large">
+    <RadioGroup value={selected} onChange={setSelected} gap="large">
+      <RadioCard value="Shrek">Shrek</RadioCard>
+      <RadioCard value="Fiona">Fiona</RadioCard>
+      <RadioCard value="Donkey">Donkey</RadioCard>
+    </RadioGroup>
+    {selected && (
+      <Text>
+        The selected character is <Strong>{selected}</Strong>
+      </Text>
+    )}
   </Fieldset>
 );
 ```
@@ -155,10 +242,10 @@ listed here.
 | Prop      | Type                                   | Default | Description                            |
 | --------- | -------------------------------------- | ------- | -------------------------------------- |
 | checked?  | boolean                                |         | When true, the radio will be checked.  |
+| data?     | [DataAttributeMap][data-attribute-map] |         | Sets data attributes on the component. |
 | disabled? | boolean                                |         | When true, the radio will be disabled. |
 | size?     | 'small' \| 'medium'                    | 'small' | The size of the radio.                 |
 | value?    | string                                 |         | The value of the radio.                |
-| data?     | [DataAttributeMap][data-attribute-map] |         | Sets data attributes on the component. |
 
 [data-attribute-map]:
   https://github.com/brighte-labs/spark-web/blob/e7f6f4285b4cfd876312cc89fbdd094039aa239a/packages/utils/src/internal/buildDataAttributes.ts#L1
@@ -170,9 +257,22 @@ are not listed here.
 
 | Prop      | Type                                     | Default   | Description                                                               |
 | --------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------- |
-| onChange  | onChange: (selectedValue: Value) => void |           | Function that is fired whenever a change event is triggered on a `Radio`. |
-| value     | string                                   |           | The value of the nested radios.                                           |
 | disabled? | boolean                                  |           | When true, disables the group of nested radios.                           |
-| size?     | 'small' \| 'medium'                      |           | The size of the nested radios.                                            |
 | message?  | string                                   |           | Provide a message, informing the user about changes in state.             |
+| onChange  | onChange: (selectedValue: Value) => void |           | Function that is fired whenever a change event is triggered on a `Radio`. |
+| size?     | 'small' \| 'medium'                      |           | The size of the nested radios.                                            |
 | tone?     | 'critical' \| 'positive' \| 'neutral'    | 'neutral' | Provide a tone to influence elements of the field, and its input.         |
+| value     | string                                   |           | The value of the nested radios.                                           |
+
+### RadioCard
+
+| Prop         | Type            | Default | Description                            |
+| ------------ | --------------- | ------- | -------------------------------------- |
+| checked?     | boolean         |         | When true, the radio will be checked.  |
+| children     | React.ReactNode |         | The radio label.                       |
+| description? | string          |         | The radio description.                 |
+| disabled?    | boolean         | false   | When true, the radio will be disabled. |
+| value?       | string          |         | The value of the radio.                |
+
+The `RadioCard` component also extends `InputHTMLAttributes` props and are not
+listed here.

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -14,7 +14,6 @@
     "@spark-web/box": "^1.0.5",
     "@spark-web/control-label": "^1.0.5",
     "@spark-web/field": "^3.0.0",
-    "@spark-web/icon": "^1.1.3",
     "@spark-web/stack": "^1.0.5",
     "@spark-web/text": "^1.0.5",
     "@spark-web/theme": "^3.0.1"

--- a/packages/radio/src/index.ts
+++ b/packages/radio/src/index.ts
@@ -1,6 +1,12 @@
 export { Radio } from './radio';
+export { RadioCard } from './radio-card';
 export { RadioGroup } from './radio-group';
 export { RadioPrimitive } from './radio-primitive';
 
 // types
-export type { RadioPrimitiveProps, RadioProps } from './types';
+export type {
+  RadioCardProps,
+  RadioGroupProps,
+  RadioPrimitiveProps,
+  RadioProps,
+} from './types';

--- a/packages/radio/src/radio-card.tsx
+++ b/packages/radio/src/radio-card.tsx
@@ -1,0 +1,140 @@
+import { css } from '@emotion/css';
+import { composeId, useFocusRing, useId } from '@spark-web/a11y';
+import { Box } from '@spark-web/box';
+import { Stack } from '@spark-web/stack';
+import { DefaultTextPropsProvider, Text } from '@spark-web/text';
+import { useTheme } from '@spark-web/theme';
+import type { ReactNode } from 'react';
+import { forwardRef, Fragment } from 'react';
+
+import { useRadioGroupContext } from './context';
+import { RadioPrimitive, useTransitionProperties } from './radio-primitive';
+import type { RadioCardProps } from './types';
+import { useRadioGroupItem } from './use-radio-group-state';
+
+export const RadioCard = forwardRef<HTMLInputElement, RadioCardProps>(
+  (
+    { children, data, description, disabled, ...consumerProps },
+    forwardedRef
+  ) => {
+    const groupState = useRadioGroupContext();
+    const radioGroupItemProps = useRadioGroupItem({
+      props: consumerProps,
+      state: groupState,
+    });
+    const inputProps =
+      typeof groupState === 'undefined' ? consumerProps : radioGroupItemProps;
+
+    const isDisabled = disabled ?? groupState?.disabled ?? false;
+    const size = 'small';
+    const [boxProps, radioCardStyles] = useRadioCardStyles(isDisabled);
+
+    const inputId = useId();
+    const labelId = composeId(inputId, 'label');
+    const descriptionId = composeId(inputId, 'description');
+
+    return (
+      <Stack
+        {...boxProps}
+        as="label"
+        htmlFor={inputId}
+        className={css(radioCardStyles)}
+      >
+        <Box alignItems="start" display="inline-flex" gap={size}>
+          <RadioPrimitive
+            {...inputProps}
+            aria-describedby={description ? descriptionId : undefined}
+            aria-labelledby={labelId}
+            data={data}
+            disabled={isDisabled}
+            id={inputId}
+            ref={forwardedRef}
+            size={size}
+          />
+          <Stack gap="large">
+            <DefaultTextPropsProvider
+              tone={isDisabled ? 'disabled' : 'neutral'}
+              weight={description ? 'semibold' : 'regular'}
+            >
+              <Content id={labelId}>{children}</Content>
+            </DefaultTextPropsProvider>
+            {description && (
+              <Text id={descriptionId} tone={isDisabled ? 'disabled' : 'muted'}>
+                {description}
+              </Text>
+            )}
+          </Stack>
+        </Box>
+      </Stack>
+    );
+  }
+);
+
+RadioCard.displayName = 'RadioCard';
+
+function Content({ children, id }: { children: ReactNode; id: string }) {
+  if (typeof children === 'string' || typeof children === 'number') {
+    return <Text id={id}>{children}</Text>;
+  }
+
+  return <Fragment>{children}</Fragment>;
+}
+
+export function useRadioCardStyles(isDisabled: boolean) {
+  const theme = useTheme();
+  const focusRingStyles = useFocusRing();
+
+  const transitionProperties = useTransitionProperties();
+
+  return [
+    // Box props to be spread onto label
+    {
+      background: isDisabled ? 'inputDisabled' : 'surface',
+      cursor: isDisabled ? 'default' : 'pointer',
+      padding: 'large',
+      position: 'relative',
+      userSelect: 'none',
+    },
+    {
+      // Simulates a border for the radio card
+      'input[type=radio] + [data-radio-border=true]': {
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        borderColor: theme.border.color.field,
+        borderStyle: 'solid',
+        borderWidth: theme.border.width.standard,
+        borderRadius: theme.border.radius.small,
+        pointerEvents: 'none',
+        ...transitionProperties,
+      },
+
+      // Change border color of card on hover (when not disabled)
+      ':hover input:not([disabled], [aria-disabled=true]) + [data-radio-border=true]':
+        {
+          borderColor: theme.border.color.primaryHover,
+        },
+
+      // Focus styles for card
+      'input[type=radio]:focus + [data-radio-border=true]': {
+        borderColor: theme.border.color.primary,
+        ...focusRingStyles,
+      },
+
+      // Remove focus ring on radio (as it is on the whole card)
+      'input[type=radio]:focus': {
+        boxShadow: 'none',
+      },
+
+      // Border style for card when checked
+      'input[type=radio]:checked + [data-radio-border=true]': {
+        borderColor: isDisabled
+          ? theme.border.color.field
+          : theme.border.color.primary,
+        borderWidth: theme.border.width.large,
+      },
+    },
+  ] as const;
+}

--- a/packages/radio/src/radio.test.tsx
+++ b/packages/radio/src/radio.test.tsx
@@ -74,7 +74,7 @@ describe('Radio component', () => {
     renderComponent({ label, value, data });
     const attributeUnderTest = screen
       .getByDisplayValue('some value')
-      .parentElement?.getAttribute('data-testattr');
+      .getAttribute('data-testattr');
     expect(attributeUnderTest).toEqual('some attr');
   });
 });

--- a/packages/radio/src/types.ts
+++ b/packages/radio/src/types.ts
@@ -58,3 +58,8 @@ export type RadioGroupProps<Value extends string> = {
   /** The value of the nested radios. */
   value: Value;
 };
+
+export type RadioCardProps = Omit<RadioProps, 'id' | 'size'> & {
+  /** The radio description. */
+  description?: string;
+};


### PR DESCRIPTION
# Description

Adds a RadioCard component to `@spark-web/radio`.
As part of this, I've refactored the `RadioPrimitive`.

I've closed my original PR to simplify a few things and will update the `RadioGroup` component in a future PR to address [this issue](https://github.com/brighte-labs/spark-web/issues/15).

# Associated Tickets

- [SPRK-14](https://brighte.atlassian.net/browse/SPRK-14)

# Checklist:

- [x] I've updated unit tests where needed
- [x] I've updated the components README.md where needed
- [x] I've added major version bumps for my breaking changes
- [x] I've added changesets where needed
- [x] All the components I've updated are reflected in the changelog
