### PR TITLE
Fix search index script

### DIFF
--- a/docs/utils/with-search-index.mjs
+++ b/docs/utils/with-search-index.mjs
@@ -32,8 +32,8 @@ function generateSearchIndex() {
   const MANIFEST_DIR = path.normalize(`${process.cwd()}/cache`);
   const outFile = `${MANIFEST_DIR}/search-index.json`;
 
-  const allPackages = JSON.parse(
-    readFileSync('./.contentlayer/generated/Package/_index.json')
+  const allPackages = readFileSync(
+    './.contentlayer/generated/Package/_index.mjs'
   );
 
   const index = lunr(function () {
@@ -96,7 +96,7 @@ export function withSearchIndex(nextConfig, { phase }) {
         // In dev mode, we need to setup a process which watches for changes to
         // the `.contentlayer` output, then triggers a re-build of our search
         // index.
-        // Beacuse we `import()` the search index file, Webpack will see that
+        // Because we `import()` the search index file, Webpack will see that
         // the file has changed and trigger a hot-reload of the Next app.
         chokidar
           .watch(
@@ -105,7 +105,7 @@ export function withSearchIndex(nextConfig, { phase }) {
               '.contentlayer',
               'generated',
               'Package',
-              '_index.json'
+              '_index.mjs'
             )
           )
           .on('all', () => {


### PR DESCRIPTION
# Description

The `withSearchIndex` script that runs when Next starts was a bit flakey. I'd often get this error:

![CleanShot 2022-06-23 at 09 18 58@2x](https://user-images.githubusercontent.com/3422401/175173872-bb644b59-415b-45be-9edb-3f0cfe36343e.png)

It seems like there can sometimes be an issue parsing the JSON that is generated by contentlayer. Thankfully contentlayer also generates a `.mjs` file with the same info, so we don't need to parse it.

I tested this locally and couldn't get it to fail.
