### PR TITLE
Fix async combobox bug

### DIFF
--- a/.changeset/shiny-pumpkins-know.md
+++ b/.changeset/shiny-pumpkins-know.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/field': patch
+---
+
+Memoize Field context

--- a/.changeset/tidy-pants-wave.md
+++ b/.changeset/tidy-pants-wave.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/combobox': patch
+---
+
+Memoize useReactSelectComponentsOverride

--- a/packages/combobox/src/combobox.tsx
+++ b/packages/combobox/src/combobox.tsx
@@ -1,12 +1,11 @@
 import { useFieldContext } from '@spark-web/field';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
-import { buildDataAttributes } from '@spark-web/utils/internal';
 import { useEffect, useRef, useState } from 'react';
 import type { GetOptionLabel, GetOptionValue, GroupBase } from 'react-select';
 import ReactSelect from 'react-select';
 
 import {
-  getReactSelectComponentsOverride,
+  useReactSelectComponentsOverride,
   useReactSelectStylesOverride,
   useReactSelectThemeOverride,
 } from './react-select-overrides';
@@ -85,17 +84,12 @@ export const Combobox = <Item,>({
   value,
   data,
 }: ComboboxProps<Item>) => {
-  const [{ disabled, invalid }, { id: inputId, ...a11yProps }] =
-    useFieldContext();
+  const [{ disabled, invalid }, { id: inputId }] = useFieldContext();
+  const { items, loading } = useAwaitableItems(_items);
 
+  const componentsOverride = useReactSelectComponentsOverride(data);
   const stylesOverride = useReactSelectStylesOverride<Item>({ invalid });
   const themeOverride = useReactSelectThemeOverride();
-  const componentsOverride = getReactSelectComponentsOverride({
-    ...a11yProps,
-    ...(data ? buildDataAttributes(data) : undefined),
-  });
-
-  const { items, loading } = useAwaitableItems(_items);
 
   return (
     <ReactSelect<Item>

--- a/packages/combobox/src/react-select-overrides.tsx
+++ b/packages/combobox/src/react-select-overrides.tsx
@@ -1,10 +1,13 @@
 import { useFocusRing } from '@spark-web/a11y';
 import { Box } from '@spark-web/box';
-import type { InputPropsDerivedFromField } from '@spark-web/field';
+import { useFieldContext } from '@spark-web/field';
 import { ChevronDownIcon } from '@spark-web/icon';
 import { Spinner } from '@spark-web/spinner';
 import { Text, useText } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
+import type { DataAttributeMap } from '@spark-web/utils/internal';
+import { buildDataAttributes } from '@spark-web/utils/internal';
+import { useMemo } from 'react';
 import type {
   GroupBase,
   SelectComponentsConfig,
@@ -13,37 +16,51 @@ import type {
 } from 'react-select';
 import { components } from 'react-select';
 
-export const getReactSelectComponentsOverride = (
-  componentProps: Omit<InputPropsDerivedFromField, 'id'>
-): SelectComponentsConfig<any, false, GroupBase<any>> => ({
-  DropdownIndicator: props => (
-    <components.DropdownIndicator {...props}>
-      <ChevronDownIcon size="xxsmall" tone="muted" />
-    </components.DropdownIndicator>
-  ),
+export const useReactSelectComponentsOverride = (
+  data?: DataAttributeMap
+): SelectComponentsConfig<any, false, GroupBase<any>> => {
+  const [, fieldProps] = useFieldContext();
 
-  Input: props => <components.Input {...props} {...componentProps} />,
+  return useMemo(
+    () => ({
+      DropdownIndicator: props => (
+        <components.DropdownIndicator {...props}>
+          <ChevronDownIcon size="xxsmall" tone="muted" />
+        </components.DropdownIndicator>
+      ),
 
-  IndicatorSeparator: () => null,
+      Input: props => (
+        <components.Input
+          {...props}
+          {...(data ? buildDataAttributes(data) : undefined)}
+          aria-invalid={fieldProps['aria-invalid']}
+          aria-describedby={fieldProps['aria-describedby']}
+        />
+      ),
 
-  LoadingIndicator: () => null,
+      IndicatorSeparator: () => null,
 
-  LoadingMessage: props => (
-    <components.LoadingMessage {...props}>
-      <Box paddingY="large">
-        <Spinner size="xsmall" tone="primary" />
-      </Box>
-    </components.LoadingMessage>
-  ),
+      LoadingIndicator: () => null,
 
-  NoOptionsMessage: props => (
-    <components.NoOptionsMessage {...props}>
-      <Box paddingY="large">
-        <Text>No matching results</Text>
-      </Box>
-    </components.NoOptionsMessage>
-  ),
-});
+      LoadingMessage: props => (
+        <components.LoadingMessage {...props}>
+          <Box paddingY="large">
+            <Spinner size="xsmall" tone="primary" />
+          </Box>
+        </components.LoadingMessage>
+      ),
+
+      NoOptionsMessage: props => (
+        <components.NoOptionsMessage {...props}>
+          <Box paddingY="large">
+            <Text>No matching results</Text>
+          </Box>
+        </components.NoOptionsMessage>
+      ),
+    }),
+    [data, fieldProps]
+  );
+};
 
 export const useReactSelectStylesOverride = <Item,>({
   invalid,

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -7,7 +7,7 @@ import { Text } from '@spark-web/text';
 import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { ReactElement, ReactNode } from 'react';
-import { forwardRef, Fragment } from 'react';
+import { forwardRef, Fragment, useMemo } from 'react';
 
 import type { FieldContextType } from './context';
 import { FieldContextProvider } from './context';
@@ -70,17 +70,28 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
 
     // field context
     const invalid = Boolean(message && tone === 'critical');
-    const fieldContext: FieldContextType = [
-      { disabled, invalid },
-      {
-        'aria-describedby': mergeIds(
-          message && messageId,
-          description && descriptionId
-        ),
-        'aria-invalid': invalid || undefined,
-        id: inputId,
-      },
-    ];
+    const fieldContext: FieldContextType = useMemo(
+      () => [
+        { disabled, invalid },
+        {
+          'aria-describedby': mergeIds(
+            message && messageId,
+            description && descriptionId
+          ),
+          'aria-invalid': invalid || undefined,
+          id: inputId,
+        },
+      ],
+      [
+        description,
+        descriptionId,
+        disabled,
+        inputId,
+        invalid,
+        message,
+        messageId,
+      ]
+    );
 
     // label prep
     const hiddenLabel = (


### PR DESCRIPTION
# Description

After changing the React Select component overrides to be a function rather than an object in https://github.com/brighte-labs/spark-web/pull/133 we introduced a bug with the [async example in the docs](https://spark-web-docs-git-luke-sprk-84-brighte.vercel.app/package/combobox#async) where you could only type 1 character and then the combobox would stop accepting new user input.

This is because the components were previously created in module scope, but they are now created in function scope, meaning that they are re-created on every render. Memoizing the components helps, but the field context was also not stable so I've _also_ memoized that.

# Associated Tickets

- [SPRK-97](https://brighte.atlassian.net/browse/SPRK-97)
