### PR TITLE
Fix alignment when heading is omitted

### DIFF
--- a/.changeset/nasty-icons-buy.md
+++ b/.changeset/nasty-icons-buy.md
@@ -1,0 +1,5 @@
+---
+'@spark-web/alert': patch
+---
+
+Fix styles and alignment

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -10,11 +10,12 @@
   "dependencies": {
     "@babel/runtime": "^7.18.3",
     "@emotion/css": "^11.9.0",
-    "@spark-web/box": "^1.0.6",
+    "@spark-web/button": "^1.2.0",
     "@spark-web/icon": "^1.1.4",
+    "@spark-web/row": "^1.1.1",
     "@spark-web/stack": "^1.0.6",
     "@spark-web/text": "^1.0.6",
-    "@spark-web/text-list": "^2.0.1",
+    "@spark-web/theme": "^3.0.2",
     "@spark-web/utils": "^1.1.5"
   },
   "devDependencies": {

--- a/packages/alert/src/Alert.test.tsx
+++ b/packages/alert/src/Alert.test.tsx
@@ -6,19 +6,18 @@ describe('Alert component', () => {
   afterEach(cleanup);
 
   it('should render correctly with the minimum set of props, without crashing', () => {
-    const { container } = render(<Alert tone={'info'}>Test</Alert>);
+    const { container } = render(<Alert tone="info">Test</Alert>);
     expect(container).toBeDefined();
   });
+
   it('should display data props when passed down', () => {
-    const test_string = 'Test string';
-    const data = { testAttr: 'some attr' };
+    const testString = 'Test string';
     const { container } = render(
-      <Alert data={data} tone={'info'}>
-        {test_string}
+      <Alert data={{ testAttr: 'some attr' }} tone="info">
+        {testString}
       </Alert>
     );
-
-    const divEl = container.querySelector('div');
-    expect(divEl?.innerHTML).toContain('data-testattr="some attr"');
+    const alertEl = container.firstElementChild;
+    expect(alertEl?.getAttribute('data-testattr')).toEqual('some attr');
   });
 });

--- a/packages/alert/src/Alert.tsx
+++ b/packages/alert/src/Alert.tsx
@@ -1,4 +1,5 @@
-import { Box } from '@spark-web/box';
+import { css } from '@emotion/css';
+import { Button } from '@spark-web/button';
 import type { IconProps } from '@spark-web/icon';
 import {
   CheckCircleIcon,
@@ -6,14 +7,22 @@ import {
   InformationCircleIcon,
   XIcon,
 } from '@spark-web/icon';
+import { Row } from '@spark-web/row';
 import { Stack } from '@spark-web/stack';
 import { Text } from '@spark-web/text';
-import { IndicatorContainer } from '@spark-web/text-list';
+import { useTheme } from '@spark-web/theme';
 import type { DataAttributeMap } from '@spark-web/utils/internal';
 import type { ReactNode } from 'react';
 import { Fragment } from 'react';
 
-type AlertTones = 'caution' | 'critical' | 'info' | 'positive';
+const toneToIcon = {
+  caution: ExclamationIcon,
+  critical: ExclamationIcon,
+  info: InformationCircleIcon,
+  positive: CheckCircleIcon,
+};
+
+type AlertTones = keyof typeof toneToIcon;
 
 export type AlertProps = {
   children: string | ReactNode;
@@ -26,7 +35,7 @@ export type AlertProps = {
   tone: AlertTones;
 };
 
-export const Alert = ({
+export function Alert({
   children,
   closeLabel = 'Close alert',
   data,
@@ -34,75 +43,73 @@ export const Alert = ({
   icon,
   onClose,
   tone = 'info',
-}: AlertProps): JSX.Element => {
+}: AlertProps) {
   const Icon = icon || toneToIcon[tone];
   const iconSize = 'xsmall';
 
   return (
-    <Box
-      role="alert"
+    <Row
       aria-live="polite"
-      background={`${tone}Muted`}
+      data={data}
+      role="alert"
+      // Styles
+      alignY={heading ? 'top' : 'center'}
+      background={`${tone}Low`}
       borderRadius="medium"
-      display="flex"
-      alignItems={heading ? 'start' : 'center'}
       gap="medium"
     >
-      <Box
-        data={data}
-        display="flex"
-        flex={1}
-        alignItems="start"
+      <Row
+        alignY="top"
         gap="medium"
         padding="large"
+        paddingRight="none"
+        width="full"
+        style={{ minWidth: 0 }}
       >
-        <IndicatorContainer>
-          <Icon tone={tone} size={iconSize} />
-        </IndicatorContainer>
+        <IconWrapper>
+          <Icon size={iconSize} tone={tone} />
+        </IconWrapper>
         <Stack flex={1} gap="medium">
           {heading && <Text weight="semibold">{heading}</Text>}
           <Content>{children}</Content>
         </Stack>
-      </Box>
+      </Row>
       {onClose && (
-        <Box padding="small">
-          {/* TODO: replace with Button component */}
-          <Box
-            as="button"
-            aria-label={closeLabel}
-            onClick={onClose}
-            type="button"
-            // Styling
-            borderRadius="small"
-            cursor="pointer"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            height="medium"
-            width="medium"
-            // NOTE: hover/focus styles etc have not been implemented
-            // as we don't have the correct tokens yet and this will soon be replaced
-            // with a `Button` component that will handle this for us.
-          >
+        <Row padding="small" alignSelf="start">
+          <Button label={closeLabel} tone={tone} prominence="low">
             <XIcon size="xxsmall" />
-          </Box>
-        </Box>
+          </Button>
+        </Row>
       )}
-    </Box>
+    </Row>
   );
-};
+}
 
-const toneToIcon = {
-  caution: ExclamationIcon,
-  critical: ExclamationIcon,
-  info: InformationCircleIcon,
-  positive: CheckCircleIcon,
-};
+function IconWrapper({ children }: { children: ReactNode }) {
+  const theme = useTheme();
+  const responsiveStyles = theme.utils.responsiveStyles({
+    mobile: { height: theme.typography.text.standard.mobile.capHeight },
+    tablet: { height: theme.typography.text.standard.tablet.capHeight },
+  });
 
-const Content = ({ children }: { children: ReactNode }) => {
+  return (
+    <Row
+      aria-hidden="true"
+      align="center"
+      alignY="center"
+      cursor="default"
+      flexShrink={0}
+      className={css(responsiveStyles)}
+    >
+      {children}
+    </Row>
+  );
+}
+
+function Content({ children }: { children: ReactNode }) {
   if (typeof children === 'string' || typeof children === 'number') {
     return <Text>{children}</Text>;
   }
 
   return <Fragment>{children}</Fragment>;
-};
+}

--- a/packages/alert/src/Alert.tsx
+++ b/packages/alert/src/Alert.tsx
@@ -45,7 +45,7 @@ export const Alert = ({
       background={`${tone}Muted`}
       borderRadius="medium"
       display="flex"
-      alignItems="start"
+      alignItems={heading ? 'start' : 'center'}
       gap="medium"
     >
       <Box


### PR DESCRIPTION
# Description

When the heading prop is omitted, but you have a dismiss button the alignment was all off.
We were also using a hand-rolled button instead of the button component, and some of the colours were wrong (not bright enough — see secondary button in screenshot below).

Before:
![PixelSnap 2022-07-13 at 09 01 53@2x](https://user-images.githubusercontent.com/3422401/178612691-b56551b8-ce80-4243-b672-7128343d326f.png)

After:
![PixelSnap 2022-07-13 at 09 02 04@2x](https://user-images.githubusercontent.com/3422401/178612703-3b9bc901-55ac-4b15-bea0-ab19098dc7a3.png)
